### PR TITLE
Use correct total set count when updating themes or plugins

### DIFF
--- a/features/theme.feature
+++ b/features/theme.feature
@@ -99,6 +99,15 @@ Feature: Manage WordPress themes
       P2 updated successfully from version 1.4.1 to version
       """
 
+    When I run `wp theme install p2 --version=1.4.1 --force`
+    Then STDOUT should not be empty
+
+    When I run `wp theme update --all`
+    Then STDOUT should contain:
+      """
+      Success: Updated 1 of 1 themes.
+      """
+
   Scenario: Get the path of an installed theme
     Given a WP install
 

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -346,7 +346,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 				\WP_CLI\Utils\format_items( $format, $status, array( 'name', 'old_version', 'new_version', 'status' ) );
 			}
 		}
-		Utils\report_batch_operation_results( $this->item_type, 'update', count( $args ), $num_updated, $errors );
+		Utils\report_batch_operation_results( $this->item_type, 'update', $num_to_update, $num_updated, $errors );
 	}
 
 	protected function _list( $_, $assoc_args ) {

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -346,7 +346,9 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 				\WP_CLI\Utils\format_items( $format, $status, array( 'name', 'old_version', 'new_version', 'status' ) );
 			}
 		}
-		Utils\report_batch_operation_results( $this->item_type, 'update', $num_to_update, $num_updated, $errors );
+
+		$total_updated = Utils\get_flag_value( $assoc_args, 'all' ) ? $num_to_update : count( $args );
+		Utils\report_batch_operation_results( $this->item_type, 'update', $total_updated, $num_updated, $errors );
 	}
 
 	protected function _list( $_, $assoc_args ) {


### PR DESCRIPTION
Instead of:

```
$ wp plugin update --all
Success: Updated 1 of 0 plugins.
```

It should be:

```
$ wp plugin update --all
Success: Updated 1 of 1 plugins.
```