### PR TITLE
Fix case typo on Theme_Mod_Command class name.

### DIFF
--- a/src/Theme_Mod_Command.php
+++ b/src/Theme_Mod_Command.php
@@ -17,7 +17,7 @@
  *     $ wp theme mod remove --all
  *     Success: Theme mods removed.
  */
-class Theme_Mod_command extends WP_CLI_Command {
+class Theme_Mod_Command extends WP_CLI_Command {
 
 	private $fields = array(
 		'key',


### PR DESCRIPTION
Issue https://github.com/wp-cli/wp-cli/issues/4141