### PR TITLE
Wrap all uses of get_plugins() with the "all_plugins" filter

### DIFF
--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -35,12 +35,7 @@ Feature: Activate WordPress plugins
     And the return code should be 1
 
   Scenario: Activate all when one plugin is hidden by "all_plugins" filter
-    Given these installed and active plugins:
-      """
-      akismet
-      jetpack
-      query-monitor
-      """
+    Given I run `wp plugin install query-monitor`
     And a wp-content/mu-plugins/hide-qm-plugin.php file:
       """
       <?php
@@ -57,8 +52,13 @@ Feature: Activate WordPress plugins
        """
 
     When I run `wp plugin activate --all`
-    Then STDOUT should not contain:
-    """
-    query-monitor
-    """
+    Then STDOUT should contain:
+      """
+      Plugin 'akismet' activated.
+      Plugin 'hello' activated.
+      """
+    And STDOUT should not contain:
+      """
+      Plugin 'query-monitor' activated.
+      """
 

--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -33,3 +33,32 @@ Feature: Activate WordPress plugins
       Plugin 'hello' activated.
       """
     And the return code should be 1
+
+  Scenario: Activate all when one plugin is hidden by "all_plugins" filter
+    Given these installed and active plugins:
+      """
+      akismet
+      jetpack
+      query-monitor
+      """
+    And a wp-content/mu-plugins/hide-qm-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Hide Query Monitor on Production
+       * Description: Hides the Query Monitor plugin on production sites
+       * Author: WP-CLI tests
+       */
+
+       add_filter( 'all_plugins', function( $all_plugins ) {
+          unset( $all_plugins['query-monitor/query-monitor.php'] );
+          return $all_plugins;
+       } );
+       """
+
+    When I run `wp plugin activate --all`
+    Then STDOUT should not contain:
+    """
+    query-monitor
+    """
+

--- a/features/plugin-deactivate.feature
+++ b/features/plugin-deactivate.feature
@@ -34,3 +34,26 @@ Feature: Deactivate WordPress plugins
       Plugin 'hello' deactivated.
       """
     And the return code should be 1
+
+  Scenario: Deactivate all when a previously active plugin is hidden by "all_plugins" filter
+    Given a wp-content/mu-plugins/hide-active-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Hide an Active Plugin
+       * Description: Hides Akismet plugin, which is already active
+       * Author: WP-CLI tests
+       */
+
+       add_filter( 'all_plugins', function( $all_plugins ) {
+          unset( $all_plugins['akismet/akismet.php'] );
+          return $all_plugins;
+       } );
+       """
+
+    When I run `wp plugin deactivate --all`
+    Then STDOUT should not contain:
+    """
+    Plugin 'akismet' deactivated.
+    """
+

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -426,8 +426,8 @@ Feature: Manage WordPress plugins
     And a wp-content/plugins/handbook/functionality-for-pages.php file:
       """
       <?php
-	  /**
-	   * Plugin Name: Handbook Functionality for Pages
+      /**
+       * Plugin Name: Handbook Functionality for Pages
        * Description: Adds handbook-like table of contents to all Pages for a site. Covers Table of Contents and the "watch this page" widget
        * Author: Nacin
        */
@@ -474,3 +474,35 @@ Feature: Manage WordPress plugins
       """
       Plugin installed successfully
       """
+
+  Scenario: Plugin hidden by "all_plugins" filter
+    Given a WP install
+    And these installed and active plugins:
+      """
+      akismet
+      jetpack
+      query-monitor
+      """
+    And a wp-content/mu-plugins/hide-qm-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Hide Query Monitor on Production
+       * Description: Hides the Query Monitor plugin on production sites
+       * Author: WP-CLI tests
+       */
+
+       add_filter( 'all_plugins', function( $all_plugins ) {
+          unset( $all_plugins['query-monitor/query-monitor.php'] );
+          return $all_plugins;
+       } );
+       """
+
+    When I run `wp plugin list --fields=name`
+    Then STDOUT should not contain:
+    """
+    query-monitor
+    """
+
+
+

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -252,7 +252,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		if ( $all ) {
 			$args = array_map( function( $file ){
 				return Utils\get_plugin_name( $file );
-			}, array_keys( apply_filters( 'all_plugins', get_plugins() ) ) );
+			}, array_keys( $this->get_all_plugins() ) );
 		}
 
 		$successes = $errors = 0;
@@ -325,7 +325,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		if ( $disable_all ) {
 			$args = array_map( function( $file ){
 				return Utils\get_plugin_name( $file );
-			}, array_keys( apply_filters( 'all_plugins', get_plugins() ) ) );
+			}, array_keys( $this->get_all_plugins() ) );
 		}
 
 		$successes = $errors = 0;
@@ -587,7 +587,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	protected function get_item_list() {
 		$items = $duplicate_names = array();
 
-		foreach ( apply_filters( 'all_plugins', get_plugins() ) as $file => $details ) {
+		foreach ( $this->get_all_plugins() as $file => $details ) {
 			$update_info = $this->get_update_info( $file );
 
 			$name = Utils\get_plugin_name( $file );
@@ -1018,5 +1018,17 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		}
 
 		return ! WP_CLI::launch( $command . $path );
+	}
+
+	/**
+	 * Get all available plugins.
+	 *
+	 * Uses the same filter core uses in plugins.php to determine which plugins
+	 * should be available to manage through the WP_Plugins_List_Table class.
+	 *
+	 * @return array
+	 */
+	private function get_all_plugins() {
+		return apply_filters( 'all_plugins', get_plugins() );
 	}
 }

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -252,7 +252,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		if ( $all ) {
 			$args = array_map( function( $file ){
 				return Utils\get_plugin_name( $file );
-			}, array_keys( get_plugins() ) );
+			}, array_keys( apply_filters( 'all_plugins', get_plugins() ) ) );
 		}
 
 		$successes = $errors = 0;
@@ -325,7 +325,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		if ( $disable_all ) {
 			$args = array_map( function( $file ){
 				return Utils\get_plugin_name( $file );
-			}, array_keys( get_plugins() ) );
+			}, array_keys( apply_filters( 'all_plugins', get_plugins() ) ) );
 		}
 
 		$successes = $errors = 0;
@@ -498,7 +498,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *
 	 * [--all]
 	 * : If set, all plugins that have updates will be updated.
-	 * 
+	 *
 	 * [--exclude=<name>]
 	 * : Comma separated list of plugin names that should be excluded from updating.
 	 *
@@ -556,7 +556,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     | nginx-cache-controller | 3.1.1       | 3.2.0       | Updated |
 	 *     +------------------------+-------------+-------------+---------+
 	 *     Success: Updated 2 of 2 plugins.
-	 * 
+	 *
 	 *     $ wp plugin update --all --exclude=akismet
 	 *     Enabling Maintenance mode...
 	 *     Downloading update from https://downloads.wordpress.org/plugin/nginx-champuru.3.2.0.zip...
@@ -587,7 +587,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	protected function get_item_list() {
 		$items = $duplicate_names = array();
 
-		foreach ( get_plugins() as $file => $details ) {
+		foreach ( apply_filters( 'all_plugins', get_plugins() ) as $file => $details ) {
 			$update_info = $this->get_update_info( $file );
 
 			$name = Utils\get_plugin_name( $file );

--- a/src/WP_CLI/Fetchers/Plugin.php
+++ b/src/WP_CLI/Fetchers/Plugin.php
@@ -14,12 +14,12 @@ class Plugin extends Base {
 
 	/**
 	 * Get a plugin object by name
-	 * 
+	 *
 	 * @param string $name
 	 * @return object|false
 	 */
 	public function get( $name ) {
-		foreach ( get_plugins() as $file => $_ ) {
+		foreach ( apply_filters( 'all_plugins', get_plugins() ) as $file => $_ ) {
 			if ( $file === "$name.php" ||
 				( $name && $file === $name ) ||
 				( dirname( $file ) === $name && $name !== '.' ) ) {


### PR DESCRIPTION
Uses the same filter used in the core list table at plugins.php, to ensure that plugin operations performed through wp-cli have the same effect as those done through the admin interface.

Includes some functional tests to ensure that if a plugin is hidden by a filter on "all_plugins":
- it will not be displayed in the output of `wp plugin list`
- it will not be activated by `wp plugin activate --all`
- it will not be deactivated by `wp plugin deactivate --all`

Fixes #30