### PR TITLE
change downloading message for theme and plugin in features

### DIFF
--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -5,8 +5,12 @@ Feature: Install WordPress plugins
 
     When I run `wp plugin install https://github.com/runcommand/one-time-login/archive/master.zip --activate`
     Then STDOUT should contain:
+      """"
+      Downloading install
+      """"
+    And STDOUT should contain:
       """
-      from https://github.com/runcommand/one-time-login/archive/master.zip
+      package from https://github.com/runcommand/one-time-login/archive/master.zip
       """
     And STDOUT should contain:
       """

--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -6,7 +6,7 @@ Feature: Install WordPress plugins
     When I run `wp plugin install https://github.com/runcommand/one-time-login/archive/master.zip --activate`
     Then STDOUT should contain:
       """
-      Downloading install package from https://github.com/runcommand/one-time-login/archive/master.zip
+      from https://github.com/runcommand/one-time-login/archive/master.zip
       """
     And STDOUT should contain:
       """

--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -49,7 +49,11 @@ Feature: Update WordPress plugins
     When I run `wp plugin install akismet --version=3.0.0 --force`
     Then STDOUT should contain:
       """"
-      from https://downloads.wordpress.org/plugin/akismet.3.0.0.zip...
+      Downloading install
+      """"
+    And STDOUT should contain:
+      """"
+      package from https://downloads.wordpress.org/plugin/akismet.3.0.0.zip...
       """"
 
     When I run `wp plugin status akismet`

--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -46,10 +46,10 @@ Feature: Update WordPress plugins
   Scenario: Exclude plugin updates from bulk updates.
     Given a WP install
 
-    When I run `wp plugin install akismet --version=3.0.0 --force`    
+    When I run `wp plugin install akismet --version=3.0.0 --force`
     Then STDOUT should contain:
       """"
-      Downloading install package from https://downloads.wordpress.org/plugin/akismet.3.0.0.zip...
+      from https://downloads.wordpress.org/plugin/akismet.3.0.0.zip...
       """"
 
     When I run `wp plugin status akismet`

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -114,7 +114,11 @@ Feature: Manage WordPress themes
     When I run `wp theme install p2 --version=1.4.1 --force`
     Then STDOUT should contain:
       """"
-      from https://downloads.wordpress.org/theme/p2.1.4.1.zip...
+      Downloading install
+      """"
+    And STDOUT should contain:
+      """"
+      package from https://downloads.wordpress.org/theme/p2.1.4.1.zip...
       """"
 
     When I run `wp theme status p2`

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -111,10 +111,10 @@ Feature: Manage WordPress themes
   Scenario: Exclude theme from bulk updates.
     Given a WP install
 
-    When I run `wp theme install p2 --version=1.4.1 --force`    
+    When I run `wp theme install p2 --version=1.4.1 --force`
     Then STDOUT should contain:
       """"
-      Downloading install package from https://downloads.wordpress.org/theme/p2.1.4.1.zip...
+      from https://downloads.wordpress.org/theme/p2.1.4.1.zip...
       """"
 
     When I run `wp theme status p2`


### PR DESCRIPTION
Some messages of the WordPress core were changed on trunk, then our tests were broken.
https://travis-ci.org/wp-cli/extension-command/jobs/272525924

Related #38, #39 

See https://core.trac.wordpress.org/ticket/41620