### PR TITLE
Include dropins like `object-cache.php` when listing installed plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,11 @@ Get a list of plugins.
 wp plugin list [--<field>=<value>] [--field=<field>] [--fields=<fields>] [--format=<format>]
 ~~~
 
+Displays a list of the plugins installed on the site with activation
+status, whether or not there's an update available, etc.
+
+Use `--status=dropin` to list installed dropins (e.g. `object-cache.php`).
+
 **OPTIONS**
 
 	[--<field>=<value>]

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -511,6 +511,12 @@ Feature: Manage WordPress plugins
     And I run `if test -d wp-content/plugins; then echo "fail"; fi`
     Then STDOUT should be empty
 
+    When I try `wp plugin list --status=dropin`
+    Then STDERR should be:
+      """
+      Error: No plugins found.
+      """
+
     When I run `wp plugin install query-monitor --activate`
     Then STDOUT should not be empty
 
@@ -519,10 +525,7 @@ Feature: Manage WordPress plugins
       | name          | status   |
       | query-monitor | active   |
 
-    When I run `wp plugin list --status=dropin`
+    When I run `wp plugin list --status=dropin --fields=name,title,description`
     Then STDOUT should be a table containing rows:
-      | name                                  | description              |
-      | db.php - Query Monitor Database Class | Custom database class.   |
-
-
-
+      | name   | title                               | description              |
+      | db.php | Query Monitor Database Class        | Custom database class.   |

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -511,12 +511,6 @@ Feature: Manage WordPress plugins
     And I run `if test -d wp-content/plugins; then echo "fail"; fi`
     Then STDOUT should be empty
 
-    When I try `wp plugin list --status=dropin`
-    Then STDERR should be:
-      """
-      Error: No plugins found.
-      """
-
     When I run `wp plugin install query-monitor --activate`
     Then STDOUT should not be empty
 

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -504,5 +504,25 @@ Feature: Manage WordPress plugins
     query-monitor
     """
 
+  Scenario: Show dropins plugin list
+    Given a WP install
+
+    When I run `rm -rf wp-content/plugins`
+    And I run `if test -d wp-content/plugins; then echo "fail"; fi`
+    Then STDOUT should be empty
+
+    When I run `wp plugin install query-monitor --activate`
+    Then STDOUT should not be empty
+
+    When I run `wp plugin list --status=active --fields=name,status`
+    Then STDOUT should be a table containing rows:
+      | name          | status   |
+      | query-monitor | active   |
+
+    When I run `wp plugin list --status=dropin`
+    Then STDOUT should be a table containing rows:
+      | name                                  | description              |
+      | db.php - Query Monitor Database Class | Custom database class.   |
+
 
 

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -886,6 +886,11 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	/**
 	 * Get a list of plugins.
 	 *
+	 * Displays a list of the plugins installed on the site with activation
+	 * status, whether or not there's an update available, etc.
+	 *
+	 * Use `--status=dropin` to list installed dropins (e.g. `object-cache.php`).
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--<field>=<value>]

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -218,6 +218,22 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			);
 		}
 
+		$raw_items = get_dropins();
+		$raw_data = _get_dropins();
+		foreach( $raw_items as $name => $item_data ) {
+			$description = ! empty( $raw_data[ $name ][0] ) ? $raw_data[ $name ][0] : '';
+			$items[ $name ] = array(
+				'name'           => $name,
+				'title'          => $item_data['Title'],
+				'description'    => $description,
+				'status'         => 'dropin',
+				'update'         => false,
+				'update_version' => NULL,
+				'update_package' => NULL,
+				'update_id' => '',
+			);
+		}
+
 		return $items;
 	}
 

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -642,6 +642,9 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		// Get drop-ins that WordPress uses.
 		$wp_dropins = _get_dropins();
 
+		// Get format for result.
+		$format = $assoc_args['format'];
+
 		$items = array();
 
 		foreach ( $dropins as $key => $dropin ) {
@@ -657,7 +660,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			$items[] = $dropin;
 		}
 
-		WP_CLI\Utils\format_items( 'table', $items, array( 'name', 'description' ) );
+		WP_CLI\Utils\format_items( $format, $items, array( 'name', 'description' ) );
 	}
 }
 

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -420,28 +420,8 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		// Force WordPress to check for updates
 		call_user_func( $this->upgrade_refresh );
 
-		if ( isset( $assoc_args['status'] )
-			&& 'plugin' === $this->item_type
-			&& 'dropin' === $assoc_args['status'] ) {
-			$raw_items = get_dropins();
-			$raw_data = _get_dropins();
-			$all_items = array();
-			foreach( $raw_items as $name => $item_data ) {
-				$description = ! empty( $raw_data[ $name ][0] ) ? $raw_data[ $name ][0] : '';
-				$all_items[] = array(
-					'name' => $name,
-					'title' => $item_data['Title'],
-					'description' => $description,
-					'status' => 'dropin',
-					'update' => 'none',
-					'update_version' => '',
-					'update_id' => '',
-				);
-			}
-			$all_items = ! empty( $all_items ) ? $all_items : false;
-		} else {
-			$all_items = $this->get_all_items();
-		}
+		$all_items = $this->get_all_items();
+
 		if ( !is_array( $all_items ) )
 			\WP_CLI::error( "No {$this->item_type}s found." );
 


### PR DESCRIPTION
Use 'wp plugin list --status=dropins' for that

Fixes #18 