### PR TITLE
add word wrapping of description field in a 'list' commands

### DIFF
--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -622,7 +622,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'version' => $details['Version'],
 				'update_id' => $file,
 				'title' => $details['Name'],
-				'description' => $details['Description'],
+				'description' => wordwrap( $details['Description'] ),
 			);
 		}
 

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -442,7 +442,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 				'version' => $theme->get('Version'),
 				'update_id' => $theme->get_stylesheet(),
 				'title' => $theme->get('Name'),
-				'description' => $theme->get('Description'),
+				'description' => wordwrap( $theme->get('Description') ),
 				'author' => $theme->get('Author'),
 			);
 


### PR DESCRIPTION
Summary

Hello. 
There is no word wrapping for theme list & plugin list commands for 'description' field 
Steps to reproduce

1 Install Wordpress
2 Install wp-cli
3 Try to get info about plugins or themes via get and list commands

ACTUAL RESULTS:
We have a word wrapping ('description' field) in a get command
[user@ bin]# /opt/plesk/php/5.4/bin/php /wp-cli/php/boot-fs.php --path="<path>" plugin get akismet
but it absent in a list command:
[user@ bin]# /opt/plesk/php/5.4/bin/php /wp-cli/php/boot-fs.php --path="<path>" plugin list

EXPECTED RESULTS:
The 'list' commands should wrap words as like it does a 'get' command
https://github.com/wp-cli/extension-command/blob/master/src/Plugin_Command.php#L775
