### PR TITLE
Ignore SSL trigger error in wp_update_themes/plugins().

### DIFF
--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -501,7 +501,13 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'version' ) != 'dev' ) {
 			WP_CLI::get_http_cache_manager()->whitelist_package( $api->download_link, $this->item_type, $api->slug, $api->version );
 		}
+
+		// Ignore failures on accessing SSL "https://api.wordpress.org/plugins/update-check/1.1/" in `wp_update_plugins()` which seem to occur intermittently.
+		set_error_handler( array( __CLASS__, 'error_handler' ), E_USER_WARNING | E_USER_NOTICE );
+
 		$result = $this->get_upgrader( $assoc_args )->install( $api->download_link );
+
+		restore_error_handler();
 
 		return $result;
 	}

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -411,7 +411,13 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'version' ) != 'dev' ) {
 			WP_CLI::get_http_cache_manager()->whitelist_package( $api->download_link, $this->item_type, $api->slug, $api->version );
 		}
+
+		// Ignore failures on accessing SSL "https://api.wordpress.org/themes/update-check/1.1/" in `wp_update_themes()` which seem to occur intermittently.
+		set_error_handler( array( __CLASS__, 'error_handler' ), E_USER_WARNING | E_USER_NOTICE );
+
 		$result = $this->get_upgrader( $assoc_args )->install( $api->download_link );
+
+		restore_error_handler();
 
 		return $result;
 	}

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -630,7 +630,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	 * Error handler to ignore failures on accessing SSL "https://api.wordpress.org/themes/update-check/1.1/" in `wp_update_themes()`
 	 * and "https://api.wordpress.org/plugins/update-check/1.1/" in `wp_update_plugins()` which seem to occur intermittently.
 	 */
-	static public function error_handler( $errno, $errstr, $errfile, $errline, $errcontext = null ) {
+	public static function error_handler( $errno, $errstr, $errfile, $errline, $errcontext = null ) {
 		// If ignoring E_USER_WARNING | E_USER_NOTICE, default.
 		if ( ! ( error_reporting() & $errno ) ) {
 			return false;

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -626,5 +626,23 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		return new \WP_CLI\Formatter( $assoc_args, $this->obj_fields, $this->item_type );
 	}
 
+	/**
+	 * Error handler to ignore failures on accessing SSL "https://api.wordpress.org/themes/update-check/1.1/" in `wp_update_themes()`
+	 * and "https://api.wordpress.org/plugins/update-check/1.1/" in `wp_update_plugins()` which seem to occur intermittently.
+	 */
+	static public function error_handler( $errno, $errstr, $errfile, $errline, $errcontext = null ) {
+		// If ignoring E_USER_WARNING | E_USER_NOTICE, default.
+		if ( ! ( error_reporting() & $errno ) ) {
+			return false;
+		}
+		// If not in "wp-includes/update.php", default.
+		$update_php = 'wp-includes/update.php';
+		if ( 0 !== substr_compare( $errfile, $update_php, -strlen( $update_php ) ) ) {
+			return false;
+		}
+		// Else assume it's in `wp_update_themes()` or `wp_update_plugins()` and just ignore it.
+		return true;
+	}
+
 }
 


### PR DESCRIPTION
See automated-tests build fail https://travis-ci.org/wp-cli/automated-tests/jobs/310154376

Same as https://github.com/wp-cli/core-command/pull/48, `wp_update_themes()` and `wp_update_plugins()` seem to fail intermittently when accessing `https://api.wordpress.org`, so suppress the error triggered by WP.

Don't know why the failures occur though....
