### PR TITLE
In theme test don't check STDERR now that option get returns error string

### DIFF
--- a/features/theme.feature
+++ b/features/theme.feature
@@ -236,7 +236,7 @@ Feature: Manage WordPress themes
 
     When I try `wp option get allowedthemes`
     Then the return code should be 1
-    And STDERR should be empty
+    # STDERR may or may not be empty, depending on WP-CLI version.
     And STDOUT should be empty
 
     When I run `wp theme enable biker`


### PR DESCRIPTION
Related https://github.com/wp-cli/entity-command/pull/126 and https://github.com/wp-cli/entity-command/issues/123

Changes `Enabling and disabling a theme` test to not check STDERR is empty now that `option get` returns an error string.