### PR TITLE
Add missing fields to plugin search subcommand docblock.

### DIFF
--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -135,11 +135,23 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     **requires**: Plugin Minimum Requirements
 	 *     **tested**: Plugin Tested Up To
 	 *     **compatibility**: Plugin Compatible With
-	 *     **rating**: Plugin Rating
+	 *     **rating**: Plugin Rating in Percent and Total Number
+	 *     **ratings**: Plugin Ratings for each star (1-5)
 	 *     **num_ratings**: Number of Plugin Ratings
 	 *     **homepage**: Plugin Author's Homepage
 	 *     **description**: Plugin's Description
 	 *     **short_description**: Plugin's Short Description
+	 *     **sections**: Plugin Readme Sections: description, installation, FAQ, screenshots, other notes, and changelog
+	 *     **downloaded**: Plugin Download Count
+	 *     **last_updated**: Plugin's Last Update
+   *     **added**: Plugin's Date Added to wordpress.org Repository
+   *     **tags**: Plugin's Tags
+	 *     **versions**: Plugin's Available Versions with D/L Link
+	 *     **donate_link**: Plugin's Donation Link
+	 *     **banners**: Plugin's Banner Image Link
+	 *     **icons**: Plugin's Icon Image Link
+	 *     **active_installs**: Plugin's Number of Active Installs
+	 *     **contributors**: Plugin's List of Contributors
 	 *
 	 * [--format=<format>]
 	 * : Render output in a particular format.

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -144,8 +144,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     **sections**: Plugin Readme Sections: description, installation, FAQ, screenshots, other notes, and changelog
 	 *     **downloaded**: Plugin Download Count
 	 *     **last_updated**: Plugin's Last Update
-   *     **added**: Plugin's Date Added to wordpress.org Repository
-   *     **tags**: Plugin's Tags
+	 *     **added**: Plugin's Date Added to wordpress.org Repository
+	 *     **tags**: Plugin's Tags
 	 *     **versions**: Plugin's Available Versions with D/L Link
 	 *     **donate_link**: Plugin's Donation Link
 	 *     **banners**: Plugin's Banner Image Link


### PR DESCRIPTION
The [dockblock for plugin search](https://github.com/wp-cli/extension-command/blob/master/src/Plugin_Command.php#L126-L142) was incomplete. I've tested all of the available [fields from plugins_api()](https://developer.wordpress.org/reference/functions/plugins_api/) and updated the ones that work.