### PR TITLE
Check args if optional and have all option.

### DIFF
--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -62,3 +62,21 @@ Feature: Activate WordPress plugins
       Plugin 'query-monitor' activated.
       """
 
+  Scenario: Not giving a slug on activate should throw an error unless --all given
+    When I try `wp plugin activate`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: Please specify one or more plugins, or use --all.
+      """
+    And STDOUT should be empty
+
+    # But don't give an error if no plugins and --all given for BC.
+    Given I run `wp plugin path`
+    And save STDOUT as {PLUGIN_DIR}
+    And an empty {PLUGIN_DIR} directory
+    When I run `wp plugin activate --all`
+    Then STDOUT should be:
+      """
+      Success: No plugins installed.
+      """

--- a/features/plugin-deactivate.feature
+++ b/features/plugin-deactivate.feature
@@ -58,3 +58,21 @@ Feature: Deactivate WordPress plugins
     Plugin 'akismet' deactivated.
     """
 
+  Scenario: Not giving a slug on deactivate should throw an error unless --all given
+    When I try `wp plugin deactivate`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: Please specify one or more plugins, or use --all.
+      """
+    And STDOUT should be empty
+
+    # But don't give an error if no plugins and --all given for BC.
+    Given I run `wp plugin path`
+    And save STDOUT as {PLUGIN_DIR}
+    And an empty {PLUGIN_DIR} directory
+    When I run `wp plugin deactivate --all`
+    Then STDOUT should be:
+      """
+      Success: No plugins installed.
+      """

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -434,3 +434,86 @@ Feature: Manage WordPress themes
       Theme stargazer details:
       """
     And STDERR should be empty
+
+  Scenario: Not giving a slug on update should throw an error unless --all given
+    Given a WP install
+    And I run `wp theme path`
+    And save STDOUT as {THEME_DIR}
+    And an empty {THEME_DIR} directory
+
+    # No themes installed. Don't give an error if --all given for BC.
+    When I run `wp theme update --all`
+    Then STDOUT should be:
+      """
+      Success: No themes installed.
+      """
+
+    When I run `wp theme update --version=0.6 --all`
+    Then STDOUT should be:
+      """
+      Success: No themes installed.
+      """
+
+    # One theme installed.
+    Given I run `wp theme install p2 --version=1.4.2`
+
+    When I try `wp theme update`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: Please specify one or more themes, or use --all.
+      """
+    And STDOUT should be empty
+
+    When I run `wp theme update --all`
+    Then STDOUT should contain:
+      """
+      Success: Updated
+      """
+
+    When I run the previous command again
+    Then STDOUT should be:
+      """
+      Success: Theme already updated.
+      """
+
+    # Note: if given version then re-installs.
+    When I run `wp theme update --version=1.4.2 --all`
+    Then STDOUT should contain:
+      """
+      Success: Installed 1 of 1 themes.
+      """
+
+    When I run the previous command again
+    Then STDOUT should contain:
+      """
+      Success: Installed 1 of 1 themes.
+      """
+
+    # Two themes installed.
+    Given I run `wp theme install --force twentytwelve --version=1.0`
+
+    When I run `wp theme update --all`
+    Then STDOUT should contain:
+      """
+      Success: Updated
+      """
+
+    When I run the previous command again
+    # BUG: Message should be in plural.
+    Then STDOUT should be:
+      """
+      Success: Theme already updated.
+      """
+
+    # Using version with all rarely makes sense and should probably error and do nothing.
+    When I try `wp theme update --version=1.4.2 --all`
+    Then the return code should be 1
+    And STDOUT should contain:
+      """
+      Success: Installed 1 of 1 themes.
+      """
+    And STDERR should be:
+      """
+      Error: Can't find the requested theme's version 1.4.2 in the WordPress.org theme repository (HTTP code 404).
+      """


### PR DESCRIPTION
Fixes #82 

Checks that plugin and theme commands with optional args `[<plugin>...]` (or `[<theme>...]`) and an `--all` option have something to do, using new helper method `check_optional_args_and_all()` in both `Plugin_Command` and `Theme_Command`.

Also documents in the tests but does not fix some outstanding buggish behaviour re non-pluralized message and using both `--version` and `--all` together.

Also closes #79 as it's related and easy to do.