### PR TITLE
Allow for modern-wordpress redirect; explicit list not search in upgr…

### DIFF
--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -114,9 +114,16 @@ Feature: Install WordPress plugins
     Given a WP install
 
     When I try `wp plugin install user-switching user-switching-not-a-plugin`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
-      Warning: Couldn't find 'user-switching-not-a-plugin' in the WordPress.org plugin directory.
+      Warning:
+      """
+    And STDERR should contain:
+      """
+      user-switching-not-a-plugin
+      """
+    And STDERR should contain:
+      """
       Error: Only installed 1 of 2 plugins.
       """
     And STDOUT should contain:
@@ -141,9 +148,16 @@ Feature: Install WordPress plugins
     And the return code should be 0
 
     When I try `wp plugin install user-switching-not-a-plugin`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
-      Warning: Couldn't find 'user-switching-not-a-plugin' in the WordPress.org plugin directory.
+      Warning:
+      """
+    And STDERR should contain:
+      """
+      user-switching-not-a-plugin
+      """
+    And STDERR should contain:
+      """
       Error: No plugins installed.
       """
     And the return code should be 1

--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -50,10 +50,7 @@ Feature: Install WordPress plugins
       """
       Plugin installed successfully.
       """
-    And STDOUT should contain:
-      """
-      Renamed Github-based project from 'modern-wordpress-master' to 'modern-wordpress'.
-      """
+    And STDOUT should match /Renamed Github-based project from 'modern-(?:wordpress|framework)-master' to 'modern-wordpress'/
     # Wrong directory.
     And the wp-content/plugins/modern-wordpress directory should exist
     And the wp-content/plugins/modern-framework directory should not exist

--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -4,9 +4,16 @@ Feature: Install WordPress themes
     Given a WP install
 
     When I try `wp theme install p2 p2-not-a-theme`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
-      Warning: Couldn't find 'p2-not-a-theme' in the WordPress.org theme directory.
+      Warning:
+      """
+    And STDERR should contain:
+      """
+      p2-not-a-theme
+      """
+    And STDERR should contain:
+      """
       Error: Only installed 1 of 2 themes.
       """
     And STDOUT should contain:
@@ -31,9 +38,16 @@ Feature: Install WordPress themes
     And the return code should be 0
 
     When I try `wp theme install p2-not-a-theme`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
-      Warning: Couldn't find 'p2-not-a-theme' in the WordPress.org theme directory.
+      Warning:
+      """
+    And STDERR should contain:
+      """
+      p2-not-a-theme
+      """
+    And STDERR should contain:
+      """
       Error: No themes installed.
       """
     And STDOUT should be empty

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -171,10 +171,10 @@ Feature: Manage WordPress themes and plugins
       """
     And the <file_to_check> file should not exist
 
-    When I run `wp <type> search <item> --per-page=2 --fields=name,slug`
-    Then STDOUT should contain:
+    When I run `wp <type> list --fields=name`
+    Then STDOUT should not contain:
       """
-      Showing 2 of
+      <item>
       """
 
     When I try `wp <type> install an-impossible-slug-because-abc3fr`

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -180,9 +180,13 @@ Feature: Manage WordPress themes and plugins
     When I try `wp <type> install an-impossible-slug-because-abc3fr`
     Then STDERR should contain:
       """
-      Warning: Couldn't find 'an-impossible-slug-because-abc3fr' in the WordPress.org <type> directory.
+      Warning:
       """
-    Then STDERR should contain:
+    And STDERR should contain:
+      """
+      an-impossible-slug-because-abc3fr
+      """
+    And STDERR should contain:
       """
       Error: No <type>s installed.
       """


### PR DESCRIPTION
Adjusts plugin slug not matching project name test to allow for redirect (should have https://github.com/wp-cli-test package for this but doing this as a temporary fix so https://github.com/wp-cli/extension-command/pull/84 can progress).

Changes upgradables test to check for not installed by listing the item explicitly (probably what was intended originally) rather than searching and being dependent on the vagaries of the wordpress.org api.