### PR TITLE
New command: `wp <plugin|theme> is-active <theme|plugin>` addressing #102 

### DIFF
--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -13,6 +13,11 @@ Feature: Manage WordPress themes and plugins
     And STDERR should be empty
     And STDOUT should be empty
 
+    When I try `wp <type> is-active <item>`
+    Then the return code should be 1
+    And STDERR should be empty
+    And STDOUT should be empty
+
     When I try `wp <type> get <item>`
     Then the return code should be 1
     And STDERR should not be empty

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -900,6 +900,37 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	}
 
 	/**
+	 * Checks if a given plugin is active.
+	 *
+	 * Returns exit code 0 when active, 1 when not active.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <plugin>
+	 * : The plugin to check.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Check whether plugin is Active; exit status 0 if active, otherwise 1
+	 *     $ wp plugin is-active hello
+	 *     $ echo $?
+	 *     1
+	 *
+	 * @subcommand is-active
+	 */
+	public function is_active( $args, $assoc_args = array() ) {
+		$network_wide = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' );
+
+		$plugin = $this->fetcher->get( $args[0] );
+
+		if ( ! $plugin ) {
+			WP_CLI::halt( 1 );
+		}
+
+		$this->check_active( $plugin->file, $network_wide ) ? WP_CLI::halt( 0 ) : WP_CLI::halt( 1 );
+	}
+
+	/**
 	 * Deletes plugin files without deactivating or uninstalling.
 	 *
 	 * ## OPTIONS

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -597,7 +597,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	 *
 	 * [--all]
 	 * : If set, all themes that have updates will be updated.
-	 * 
+	 *
 	 * [--exclude=<theme-names>]
 	 * : Comma separated list of theme names that should be excluded from updating.
 	 *
@@ -639,7 +639,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     | twentysixteen | 1.1         | 1.2         | Updated |
 	 *     +---------------+-------------+-------------+---------+
 	 *     Success: Updated 2 of 2 themes.
-	 * 
+	 *
 	 *     # Exclude themes updates when bulk updating the themes
 	 *     $ wp theme update --all --exclude=twentyfifteen
 	 *     Downloading update from https://downloads.wordpress.org/theme/astra.1.0.5.1.zip...
@@ -714,6 +714,37 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		} else {
 			WP_CLI::halt( 1 );
 		}
+	}
+
+	/**
+	 * Checks if a given theme is active.
+	 *
+	 * Returns exit code 0 when active, 1 when not active.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <theme>
+	 * : The plugin to check.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Check whether theme is Active; exit status 0 if active, otherwise 1
+	 *     $ wp theme is-active twentyfifteen
+	 *     $ echo $?
+	 *     1
+	 *
+	 * @subcommand is-active
+	 */
+	public function is_active( $args, $assoc_args = array() ) {
+		$network_wide = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' );
+
+		$theme = wp_get_theme( $args[0] );
+
+		if ( ! $theme->exists() ) {
+			WP_CLI::halt( 1 );
+		}
+
+		$this->is_active_theme( $theme ) ? WP_CLI::halt( 0 ) : WP_CLI::halt( 1 );
 	}
 
 	/**

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -736,8 +736,6 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	 * @subcommand is-active
 	 */
 	public function is_active( $args, $assoc_args = array() ) {
-		$network_wide = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' );
-
 		$theme = wp_get_theme( $args[0] );
 
 		if ( ! $theme->exists() ) {


### PR DESCRIPTION
This pull request addresses the idea https://github.com/wp-cli/ideas/issues/102, which requests a new command, `wp plugin is-active <plugin>`. It has been implemented and also, to keep the consistency, `wp theme is-active <theme>` has been included in this pull request as well.
