### PR TITLE
Search: Add plugin or theme's URL on wordpress.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ search query.
     **icons**: Plugin's Icon Image Link
     **active_installs**: Plugin's Number of Active Installs
     **contributors**: Plugin's List of Contributors
+    **url**: Plugin's URL on wordpress.org
 
 	[--format=<format>]
 		Render output in a particular format.
@@ -1206,6 +1207,7 @@ search query.
     **num_ratings**: Number of Theme Ratings
     **homepage**: Theme Author's Homepage
     **description**: Theme Description
+    **url**: Theme's URL on wordpress.org
 
 	[--format=<format>]
 		Render output in a particular format.
@@ -1340,6 +1342,44 @@ wp theme update [<theme>...] [--all] [--exclude=<theme-names>] [--format=<format
 
     # Update all themes
     $ wp theme update --all
+
+
+
+### wp theme mod list
+
+Gets a list of theme mods.
+
+~~~
+wp theme mod list [--field=<field>] [--format=<format>]
+~~~
+
+**OPTIONS**
+
+	[--field=<field>]
+		Returns the value of a single field.
+
+	[--format=<format>]
+		Render output in a particular format.
+		---
+		default: table
+		options:
+		  - table
+		  - json
+		  - csv
+		  - yaml
+		---
+
+**EXAMPLES**
+
+    # Gets a list of theme mods.
+    $ wp theme mod list
+    +------------------+---------+
+    | key              | value   |
+    +------------------+---------+
+    | background_color | dd3333  |
+    | link_color       | #dd9933 |
+    | main_text_color  | #8224e3 |
+    +------------------+---------+
 
 ## Installing
 

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -152,6 +152,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     **icons**: Plugin's Icon Image Link
 	 *     **active_installs**: Plugin's Number of Active Installs
 	 *     **contributors**: Plugin's List of Contributors
+	 *     **url**: Plugin's URL on wordpress.org
 	 *
 	 * [--format=<format>]
 	 * : Render output in a particular format.

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -125,6 +125,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     **num_ratings**: Number of Theme Ratings
 	 *     **homepage**: Theme Author's Homepage
 	 *     **description**: Theme Description
+	 *     **url**: Theme's URL on wordpress.org
 	 *
 	 * [--format=<format>]
 	 * : Render output in a particular format.

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -613,6 +613,11 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		$items = $api->$plural;
 
+		// Add `url` for plugin or theme on wordpress.org.
+		foreach ( $items as $index => $item_object ) {
+			$item_object->url = "https://wordpress.org/{$plural}/{$item_object->slug}/";
+		}
+
 		if ( 'table' === $format ) {
 			$count = \WP_CLI\Utils\get_flag_value( $api->info, 'results', 'unknown' );
 			\WP_CLI::success( sprintf( 'Showing %s of %s %s.', count( $items ), $count, $plural ) );

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -615,7 +615,9 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		// Add `url` for plugin or theme on wordpress.org.
 		foreach ( $items as $index => $item_object ) {
-			$item_object->url = "https://wordpress.org/{$plural}/{$item_object->slug}/";
+			if ( $item_object instanceof \stdClass ) {
+				$item_object->url = "https://wordpress.org/{$plural}/{$item_object->slug}/";
+			}
 		}
 
 		if ( 'table' === $format ) {


### PR DESCRIPTION
After the plugin_api() or theme_api() call is made, update the results with the generated URL for wordpress.org, made up of a hard-coded domain name, the plural of the item type, and the item's slug.

Fixes #94.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
