### PR TITLE
wp plugin delete <plugin-name> not working if path has a space or & in it

### DIFF
--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1132,7 +1132,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			$command = 'rm -rf ';
 		}
 
-		return ! WP_CLI::launch( $command . $path );
+		return ! WP_CLI::launch( $command . escapeshellarg( $path ) );
 	}
 
 	/**


### PR DESCRIPTION
fixes https://github.com/wp-cli/extension-command/issues/135