### PR TITLE
🐛 FIX: Failed plugin updates not throwing errors

### DIFF
--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -196,11 +196,14 @@ Feature: Update WordPress plugins
     Given a WP install
     And I run `wp plugin install --force akismet --version=4.0`
     And I run `chmod -w wp-content/plugins/akismet`
-    When I try `wp plugin update akismet`
+    And I try `wp plugin update akismet`
+    And save STDERR as {ERROR}
+    And I run `chmod +w wp-content/plugins/akismet`
 
-    Then STDERR should contain:
+    And I run `echo "{ERROR}"`
+    Then STDOUT should contain:
       """
       Error: 
       """
 
-    And I run `chmod +w wp-content/plugins/akismet`
+    

--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -191,3 +191,16 @@ Feature: Update WordPress plugins
       """
       Error: Can't find the requested plugin's version 2.5.4 in the WordPress.org plugin repository (HTTP code 404).
       """
+
+  Scenario: Plugin updates that error should not report a success
+    Given a WP install
+    And I run `wp plugin install --force akismet --version=4.0`
+    And I run `chmod -w wp-content/plugins/akismet`
+    When I try `wp plugin update akismet`
+
+    Then STDERR should contain:
+      """
+      Error: 
+      """
+
+    And I run `chmod +w wp-content/plugins/akismet`

--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -192,6 +192,7 @@ Feature: Update WordPress plugins
       Error: Can't find the requested plugin's version 2.5.4 in the WordPress.org plugin repository (HTTP code 404).
       """
 
+  @require-wp-4.7
   Scenario: Plugin updates that error should not report a success
     Given a WP install
     And I run `wp plugin install --force akismet --version=4.0`

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -500,6 +500,7 @@ Feature: Manage WordPress plugins
       """
     And the return code should be 0
 
+  @require-wp-47
   Scenario: Plugin hidden by "all_plugins" filter
     Given a WP install
     And these installed and active plugins:

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -401,6 +401,9 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 						'new_version' => $info['update_version'],
 						'status' => $result[ $info['update_id'] ] !== null ? 'Updated' : 'Error',
 					);
+					if ( $result[ $info['update_id'] ] == null ) {
+						$errors++;
+					}
 				}
 
 				$format = 'table';


### PR DESCRIPTION
Resolve issue #90. This checks for a null response from bulk_upgrade and assumes a plugin update did not occur. That may include more errors than intended as plugin update errors are not included in response. Refer to https://developer.wordpress.org/reference/classes/plugin_upgrader/.