### PR TITLE
Added optional argument --exclude for plugin deactivate --all

### DIFF
--- a/features/plugin-deactivate.feature
+++ b/features/plugin-deactivate.feature
@@ -76,3 +76,22 @@ Feature: Deactivate WordPress plugins
       """
       Success: No plugins installed.
       """
+      
+  Scenario: Adding --exclude with plugin deactivate --all should exclude the plugins specified via --exclude
+    When I try `wp plugin deactivate --all --exclude=hello`
+    Then STDOUT should be:
+      """
+      Plugin 'akismet' deactivated.
+      Success: Deactivated 1 of 1 plugins.
+      """
+    And the return code should be 0
+
+  Scenario: Adding --exclude with plugin deactivate should throw an error unless --all given
+    When I try `wp plugin deactivate --exclude=hello`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: Please specify one or more plugins, or use --all.
+      """
+    And STDOUT should be empty
+    

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -337,6 +337,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * [--all]
 	 * : If set, all plugins will be deactivated.
 	 *
+	 * [--exclude=<name>]
+	 * : Comma separated list of plugin names that should be excluded from deactivation.
+	 *
 	 * [--network]
 	 * : If set, the plugin will be deactivated for the entire multisite network.
 	 *
@@ -346,12 +349,19 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     $ wp plugin deactivate hello
 	 *     Plugin 'hello' deactivated.
 	 *     Success: Deactivated 1 of 1 plugins.
+	 *
+	 *     # Deactivate all plugins with exclusion
+	 *     $ wp plugin deactivate --all --exclude=hello,wordpress-seo
+	 *     Plugin 'contact-form-7' deactivated.
+	 *     Plugin 'ninja-forms' deactivated.
+	 *     Success: Deactivated 2 of 2 plugins.
 	 */
 	public function deactivate( $args, $assoc_args = array() ) {
 		$network_wide = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' );
 		$disable_all = \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' );
+		$disable_all_exclude = \WP_CLI\Utils\get_flag_value( $assoc_args, 'exclude' );
 
-		if ( ! ( $args = $this->check_optional_args_and_all( $args, $disable_all ) ) ) {
+		if ( ! ( $args = $this->check_optional_args_and_all( $args, $disable_all, null, $disable_all_exclude ) ) ) {
 			return;
 		}
 
@@ -1152,13 +1162,30 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *
 	 * @param array $args Passed-in arguments.
 	 * @param bool $all All flag.
+	 * @param string $exclude Comma separated list of plugin slugs.
 	 * @return array Same as $args if not all, otherwise all slugs.
 	 */
-	private function check_optional_args_and_all( $args, $all, $verb = 'install' ) {
+	private function check_optional_args_and_all( $args, $all, $verb = 'install', $exclude = null ) {
+		// Workaround for optional argument $verb
+		if ( empty( $verb ) ) {
+			$verb = 'install';
+		}
+
 		if ( $all ) {
 			$args = array_map( function( $file ){
 				return Utils\get_plugin_name( $file );
 			}, array_keys( $this->get_all_plugins() ) );
+		}
+
+		// If $all & $exclude are present, remove specified slugs from $args.
+		if ( $all && $exclude ) {
+			$exclude_list = explode( ',', trim( $exclude, ',' ) );
+			foreach ( $exclude_list as $exclude_item ) {
+				$exclude_index = array_search( $exclude_item, $args, true );
+				if ( false !== $exclude_index ) {
+					unset( $args[ $exclude_index ] );
+				}
+			}
 		}
 
 		if ( empty( $args ) ) {


### PR DESCRIPTION
Added optional argument `--exclude` for `plugin deactivate --all` where plugin slugs can be specified as comma-separated. 

Objective: Allow users to exclude specific plugins from deactivation.
E.g. `wp plugin deactivate --all --exclude=jetpack,akismet`

Also, the `--exclude` parameter will work only if `--all` is specified. I've added 2 additional tests to check this feature under `features/plugin-deactivate.feature` 

This is my first contribution to WordPress community. Suggestions and modifications to improve this are appreciated. If this can be achieved with less changes, I'm happy to learn about it as well.