### PR TITLE
WP-CLI Themes: Added workaround to eqalize folder naming conventions across Win/Mac/Linux

### DIFF
--- a/src/WP_CLI/Fetchers/Theme.php
+++ b/src/WP_CLI/Fetchers/Theme.php
@@ -19,11 +19,15 @@ class Theme extends Base {
 	 * @return object|false
 	 */
 	public function get( $name ) {
-		$theme = wp_get_theme( $name );
-
-		if ( !$theme->exists() ) {
+		// Workaround to equalize folder naming conventions across Win/Mac/Linux
+		// Returns false if theme stylesheet doesn't exactly match existing themes.
+		$existing_themes = wp_get_themes();
+		$existing_stylesheets = array_keys( $existing_themes );
+		if ( ! in_array( $name, $existing_stylesheets, true ) ) {
 			return false;
 		}
+
+		$theme = $existing_themes[ $name ];
 
 		return $theme;
 	}


### PR DESCRIPTION
Modified Theme Fetcher to strict compare specified theme slug against existing ones as a Workaround to Operating System folder naming conventions.

This will equalize the non-lowercase slugs across all operating systems. If exact slug is not found, error is returned.

Fix to #121 