### PR TITLE
Display warning in plugin list info if plugin version is higher than expected

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -107,6 +107,7 @@ Feature: Manage WordPress plugins
     And STDOUT should be empty
     And the return code should be 1
 
+  @require-wp-4.0
   Scenario: Install a plugin, activate, then force install an older version of the plugin
     Given a WP install
 

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -563,9 +563,12 @@ Feature: Manage WordPress plugins
        */
 
       add_filter( 'site_transient_update_plugins', function( $value ) {
-          if ( isset( $value->no_update['hello-dolly/hello.php'] ) ) {
-                  $value->no_update['hello-dolly/hello.php']->new_version = '1.5';
-          }
+          	if ( isset( $value->response ) ) {
+              unset ( $value->response['hello-dolly/hello.php'] );
+            }
+            if ( isset( $value->no_update ) && isset( $value->no_update['hello-dolly/hello.php'] ) ) {
+              $value->no_update['hello-dolly/hello.php']->new_version = '1.5';
+            }
           return $value;
        } );
       ?>

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -172,7 +172,7 @@ Feature: Manage WordPress plugins
       """
     And STDERR should contain:
       """
-      Error: Only updated 1 of 3 plugins.
+      Error: Only updated 2 of 3 plugins.
       """
     And the return code should be 1
 

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -563,14 +563,15 @@ Feature: Manage WordPress plugins
        */
 
       add_filter( 'site_transient_update_plugins', function( $value ) {
-          	if ( isset( $value->response ) ) {
-              unset ( $value->response['hello-dolly/hello.php'] );
-            }
-            if ( isset( $value->no_update ) && isset( $value->no_update['hello-dolly/hello.php'] ) ) {
-              $value->no_update['hello-dolly/hello.php']->new_version = '1.5';
-            }
+          if ( ! is_object( $value ) ) {
+              return $value;
+          }
+
+          unset( $value->response['hello-dolly/hello.php'] );
+          $value->no_update['hello-dolly/hello.php']->new_version = '1.5';
+
           return $value;
-       } );
+      } );
       ?>
       """
 

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -628,7 +628,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 		foreach ( $this->get_all_plugins() as $file => $details ) {
 			$all_update_info = $this->get_update_info();
-			$update_info     = ( null !== $all_update_info->response[$file] ) ? (array) $all_update_info->response[$file] : null;
+			$update_info     = ( isset( $all_update_info->response[$file] ) && null !== $all_update_info->response[$file] ) ? (array) $all_update_info->response[$file] : null;
 			$name            = Utils\get_plugin_name( $file );
 
 			if ( ! isset( $duplicate_names[ $name ] ) ) {
@@ -651,7 +651,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			if ( null === $update_info ) {
 
 				// Get all plugin info that don't have an update.
-				$plugin_update_info = $all_update_info->no_update[$file];
+				$plugin_update_info = ( isset( $all_update_info->no_update[$file] ) ) ? $all_update_info->no_update[$file] : null;
 
 				// Compare version and update information in plugin list.
 				if ( null !== $plugin_update_info && version_compare($details['Version'], $plugin_update_info->new_version, '>') ) {

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -654,7 +654,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				$plugin_update_info = ( isset( $all_update_info->no_update[$file] ) ) ? $all_update_info->no_update[$file] : null;
 
 				// Compare version and update information in plugin list.
-				if ( null !== $plugin_update_info && version_compare($details['Version'], $plugin_update_info->new_version, '>') ) {
+				if ( null !== $plugin_update_info && version_compare( $details['Version'], $plugin_update_info->new_version, '>' ) ) {
 					$items[ $file ]['update'] = 'This version is higher than expected!';
 				}
 			}

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -650,12 +650,12 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 			if ( null === $update_info ) {
 
-				// Get all plugin info that don't have an update.
-				$plugin_update_info = ( isset( $all_update_info->no_update[$file] ) ) ? $all_update_info->no_update[$file] : null;
+				// Get info for all plugins that don't have an update.
+				$plugin_update_info = isset( $all_update_info->no_update[ $file ] ) ? $all_update_info->no_update[ $file ] : null;
 
 				// Compare version and update information in plugin list.
 				if ( null !== $plugin_update_info && version_compare( $details['Version'], $plugin_update_info->new_version, '>' ) ) {
-					$items[ $file ]['update'] = 'This version is higher than expected!';
+					$items[ $file ]['update'] = 'version higher than expected';
 				}
 			}
 		}

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -438,7 +438,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		}
 
 		$all_update_info = $this->get_update_info();
-		$checked_themes  = ( isset( $all_update_info->checked ) ) ? $all_update_info->checked : array();
+		$checked_themes  = isset( $all_update_info->checked ) ? $all_update_info->checked : array();
 
 		if ( ! empty( $checked_themes ) ) {
 			foreach ( $checked_themes as $slug => $version ) {
@@ -449,7 +449,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		foreach ( wp_get_themes() as $key => $theme ) {
 			$file = $theme->get_stylesheet_directory();
 
-			$update_info = ( isset( $all_update_info->response[$theme->get_stylesheet()]) && null !== $all_update_info->response[$theme->get_stylesheet()] ) ? (array) $all_update_info->response[$theme->get_stylesheet()] : null;
+			$update_info = ( isset( $all_update_info->response[ $theme->get_stylesheet() ] ) && null !== $all_update_info->response[ $theme->get_stylesheet() ] ) ? (array) $all_update_info->response[ $theme->get_stylesheet() ] : null;
 
 			$items[ $file ] = array(
 				'name' => $key,
@@ -466,7 +466,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 
 			// Compare version and update information in theme list.
 			if ( isset( $theme_version_info[ $key ] ) && false === $theme_version_info[ $key ] ) {
-				$items[ $file ]['update'] = 'This version is higher than expected!';
+				$items[ $file ]['update'] = 'version higher than expected';
 			}
 
 			if ( is_multisite() ) {
@@ -917,7 +917,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	}
 
 	/**
-	 * Check if current version of the theme is higher than the one available at WP.org
+	 * Check if current version of the theme is higher than the one available at WP.org.
 	 *
 	 * @param string $slug Theme slug.
 	 * @param string $version Theme current version.
@@ -928,17 +928,13 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		// Get Theme Info.
 		$theme_info = themes_api( 'theme_information', array( 'slug' => $slug ) );
 
-		// Return empty string for themes not on WP.org
+		// Return empty string for themes not on WP.org.
 		if ( is_wp_error( $theme_info ) ) {
 			return '';
 		}
 
 		// Compare theme version info.
-		if ( version_compare( $version, $theme_info->version, '>' ) ) {
-			return false;
-		} else {
-			return true;
-		}
+		return ! version_compare( $version, $theme_info->version, '>' );
 
 	}
 }

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -438,7 +438,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		}
 
 		$all_update_info = $this->get_update_info();
-		$checked_themes  = $all_update_info->checked;
+		$checked_themes  = ( isset( $all_update_info->checked ) ) ? $all_update_info->checked : array();
 
 		if ( ! empty( $checked_themes ) ) {
 			foreach ( $checked_themes as $slug => $version ) {

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -438,7 +438,9 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 
 		foreach ( wp_get_themes() as $key => $theme ) {
 			$file = $theme->get_stylesheet_directory();
-			$update_info = $this->get_update_info( $theme->get_stylesheet() );
+
+			$all_update_info = $this->get_update_info();
+			$update_info     = ( null !== $all_update_info->response[$theme->get_stylesheet()] ) ? (array) $all_update_info->response[$theme->get_stylesheet()] : null;
 
 			$items[ $file ] = array(
 				'name' => $key,
@@ -870,18 +872,18 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 
 		return $args;
 	}
-	
+
 	/**
 	 * Gets the template path based on installation type.
 	 */
 	private static function get_template_path( $template ) {
 		$command_root = Utils\phar_safe_path( dirname( __DIR__ ) );
 		$template_path = "{$command_root}/templates/{$template}";
-		
+
 		if ( ! file_exists( $template_path ) ) {
 			WP_CLI::error( "Couldn't find {$template}" );
 		}
-		
+
 		return $template_path;
 	}
 }

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -424,7 +424,8 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	}
 
 	protected function get_item_list() {
-		$items = array();
+		$items              = array();
+		$theme_version_info = array();
 
 		if ( is_multisite() ) {
 			$site_enabled = get_option( 'allowedthemes' );
@@ -436,11 +437,19 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 				$network_enabled = array();
 		}
 
+		$all_update_info = $this->get_update_info();
+		$checked_themes  = $all_update_info->checked;
+
+		if ( ! empty( $checked_themes ) ) {
+			foreach ( $checked_themes as $slug => $version ) {
+				$theme_version_info[$slug] = $this->is_theme_version_valid( $slug, $version );
+			}
+		}
+
 		foreach ( wp_get_themes() as $key => $theme ) {
 			$file = $theme->get_stylesheet_directory();
 
-			$all_update_info = $this->get_update_info();
-			$update_info     = ( isset( $all_update_info->response[$theme->get_stylesheet()]) && null !== $all_update_info->response[$theme->get_stylesheet()] ) ? (array) $all_update_info->response[$theme->get_stylesheet()] : null;
+			$update_info = ( isset( $all_update_info->response[$theme->get_stylesheet()]) && null !== $all_update_info->response[$theme->get_stylesheet()] ) ? (array) $all_update_info->response[$theme->get_stylesheet()] : null;
 
 			$items[ $file ] = array(
 				'name' => $key,
@@ -454,6 +463,11 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 				'description' => wordwrap( $theme->get('Description') ),
 				'author' => $theme->get('Author'),
 			);
+
+			// Compare version and update information in theme list.
+			if ( isset( $theme_version_info[ $key ] ) && false === $theme_version_info[ $key ] ) {
+				$items[ $file ]['update'] = 'This version is higher than expected!';
+			}
 
 			if ( is_multisite() ) {
 				if ( ! empty( $site_enabled[ $key ] ) && ! empty( $network_enabled[ $key ] ) )
@@ -885,5 +899,31 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		}
 
 		return $template_path;
+	}
+
+	/**
+	 * Check if current version of the theme is higher than the one available at WP.org
+	 *
+	 * @param string $slug Theme slug.
+	 * @param string $version Theme current version.
+	 *
+	 * @return bool|string
+	 */
+	protected function is_theme_version_valid( $slug, $version ) {
+		// Get Theme Info.
+		$theme_info = themes_api( 'theme_information', array( 'slug' => $slug ) );
+
+		// Return empty string for themes not on WP.org
+		if ( is_wp_error( $theme_info ) ) {
+			return '';
+		}
+
+		// Compare theme version info.
+		if ( version_compare( $version, $theme_info->version, '>' ) ) {
+			return false;
+		} else {
+			return true;
+		}
+
 	}
 }

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -440,7 +440,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 			$file = $theme->get_stylesheet_directory();
 
 			$all_update_info = $this->get_update_info();
-			$update_info     = ( null !== $all_update_info->response[$theme->get_stylesheet()] ) ? (array) $all_update_info->response[$theme->get_stylesheet()] : null;
+			$update_info     = ( isset( $all_update_info->response[$theme->get_stylesheet()]) && null !== $all_update_info->response[$theme->get_stylesheet()] ) ? (array) $all_update_info->response[$theme->get_stylesheet()] : null;
 
 			$items[ $file ] = array(
 				'name' => $key,

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -471,7 +471,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	/**
 	 * Get the available update info
 	 *
-	 * @return array
+	 * @return mixed
 	 */
 	protected function get_update_info() {
 		return get_site_transient( $this->upgrade_transient );

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -471,17 +471,10 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	/**
 	 * Get the available update info
 	 *
-	 * @param string $slug The plugin/theme slug
-	 *
-	 * @return array|null
+	 * @return array
 	 */
-	protected function get_update_info( $slug ) {
-		$update_list = get_site_transient( $this->upgrade_transient );
-
-		if ( !isset( $update_list->response[ $slug ] ) )
-			return null;
-
-		return (array) $update_list->response[ $slug ];
+	protected function get_update_info() {
+		return get_site_transient( $this->upgrade_transient );
 	}
 
 	private $map = array(


### PR DESCRIPTION
Fixes #142

```
+------------------+----------+---------------------------------------+---------+
| name             | status   | update                                | version |
+------------------+----------+---------------------------------------+---------+
| akismet          | inactive | This version is higher than expected! | 999     |
| woocommerce      | inactive | available                             | 3.4.5   |
+------------------+----------+---------------------------------------+---------+
```

Theme List
```
+-----------------+----------+---------------------------------------+---------+
| name            | status   | update                                | version |
+-----------------+----------+---------------------------------------+---------+
| custom-theme    | inactive | none                                  | 1.0.26  |
| twentynineteen  | inactive | This version is higher than expected! | 1.5     |
| twentyseventeen | active   | available                             | 2.0     |
| twentysixteen   | inactive | none                                  | 1.9     |
+-----------------+----------+---------------------------------------+---------+
```