### PR TITLE
Add theme status in `wp theme get` command

### DIFF
--- a/features/theme.feature
+++ b/features/theme.feature
@@ -524,8 +524,14 @@ Feature: Manage WordPress themes
     When I run `wp theme install p2`
     Then STDOUT should not be empty
 
-    When I run `wp theme get p2 --field=status`
+    When I run `wp theme get p2`
     Then STDOUT should contain:
+       """
+       status
+       """
+
+    When I run `wp theme get p2 --field=status`
+    Then STDOUT should be:
        """
        inactive
        """
@@ -534,7 +540,7 @@ Feature: Manage WordPress themes
     Then STDOUT should not be empty
 
     When I run `wp theme get p2 --field=status`
-    Then STDOUT should contain:
+    Then STDOUT should be:
        """
        active
        """

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -525,10 +525,9 @@ Feature: Manage WordPress themes
     Then STDOUT should not be empty
 
     When I run `wp theme get p2`
-    Then STDOUT should contain:
-       """
-       status
-       """
+    Then STDOUT should be a table containing rows:
+    | Field   | Value     |
+    | status  | inactive  |
 
     When I run `wp theme get p2 --field=status`
     Then STDOUT should be:

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -517,3 +517,24 @@ Feature: Manage WordPress themes
       """
       Error: Can't find the requested theme's version 1.4.2 in the WordPress.org theme repository (HTTP code 404).
       """
+
+  Scenario: Get status field in theme detail
+    Given a WP install
+
+    When I run `wp theme install p2`
+    Then STDOUT should not be empty
+
+    When I run `wp theme get p2 --field=status`
+    Then STDOUT should contain:
+       """
+       inactive
+       """
+
+    When I run `wp theme activate p2`
+    Then STDOUT should not be empty
+
+    When I run `wp theme get p2 --field=status`
+    Then STDOUT should contain:
+       """
+       active
+       """

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -606,6 +606,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 			'name',
 			'title',
 			'version',
+			'status',
 			'parent_theme',
 			'template_dir',
 			'stylesheet_dir',
@@ -623,6 +624,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 			$theme_obj->$var = $theme->$var;
 		}
 
+		$theme_obj->status      = $this->get_status( $theme );
 		$theme_obj->description = wordwrap( $theme_obj->description );
 
 		if ( empty( $assoc_args['fields'] ) ) {


### PR DESCRIPTION
Add theme status filed for `wp theme get` command.

Fixes #172 