### PR TITLE
Avoid using the Hello Dolly plugin for testing forced version updates

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -166,14 +166,18 @@ Feature: Manage WordPress plugins
     When I run `wp plugin install wordpress-importer --version=0.5 --force`
     Then STDOUT should not be empty
 
-    When I try `wp plugin update wordpress-importer hello xxx`
+    When I try `wp plugin update xxx wordpress-importer yyy`
     Then STDERR should contain:
       """
       Warning: The 'xxx' plugin could not be found.
       """
+    Then STDERR should contain:
+      """
+      Warning: The 'yyy' plugin could not be found.
+      """
     And STDERR should contain:
       """
-      Error: Only updated 2 of 3 plugins.
+      Error: Only updated 1 of 3 plugins.
       """
     And the return code should be 1
 


### PR DESCRIPTION
I don't think the Hello Dolly plugin does add anything useful to this particular test, and it seems to cause unexpected failures.

Fixes a [test failure](https://travis-ci.org/wp-cli/extension-command/builds/537730179).