### PR TITLE
#129 Added `slug` field for plugins list

### DIFF
--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -234,6 +234,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'update_id'      => '',
 				'title'          => '',
 				'description'    => '',
+				'slug'           => $file,
 			);
 		}
 
@@ -250,6 +251,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'update_version' => null,
 				'update_package' => null,
 				'update_id'      => '',
+				'slug'           => $file,
 			];
 		}
 
@@ -663,6 +665,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'update_id'      => $file,
 				'title'          => $details['Name'],
 				'description'    => wordwrap( $details['Description'] ),
+				'slug'           => $file,
 			];
 
 			if ( null === $update_info ) {
@@ -1058,6 +1061,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * * update_id
 	 * * title
 	 * * description
+	 * * slug
 	 *
 	 * ## EXAMPLES
 	 *


### PR DESCRIPTION
Hi,
This fixes #129. Let me know if I can improve this.

A test output of the `plugin list` command is below:
```
$ vendor/bin/wp plugin list --path='C:\\xampp\\htdocs\\cospol.local'
+------------------------------+----------+-----------+---------+
| name                         | status   | update    | version |
+------------------------------+----------+-----------+---------+
| contact-form-7               | inactive | none      | 5.1.3   |
| health-check                 | active   | none      | 1.3.2   |
| one-click-close-comments     | inactive | none      | 2.6     |
| user-switching               | active   | available | 1.5.0   |
| health-check-disable-plugins | must-use | none      | 1.3     |
+------------------------------+----------+-----------+---------+

$ vendor/bin/wp plugin list --path='C:\\xampp\\htdocs\\cospol.local' --field=slug
contact-form-7/wp-contact-form-7.php
health-check/health-check.php
one-click-close-comments/one-click-close-comments.php
user-switching/user-switching.php
health-check-disable-plugins.php

$ vendor/bin/wp plugin list --path='C:\\xampp\\htdocs\\cospol.local' --fields=slug
+-------------------------------------------------------+
| slug                                                  |
+-------------------------------------------------------+
| contact-form-7/wp-contact-form-7.php                  |
| health-check/health-check.php                         |
| one-click-close-comments/one-click-close-comments.php |
| user-switching/user-switching.php                     |
| health-check-disable-plugins.php                      |
+-------------------------------------------------------+

$ vendor/bin/wp plugin list --path='C:\\xampp\\htdocs\\cospol.local' --fields=name,slug
+------------------------------+-------------------------------------------------------+
| name                         | slug                                                  |
+------------------------------+-------------------------------------------------------+
| contact-form-7               | contact-form-7/wp-contact-form-7.php                  |
| health-check                 | health-check/health-check.php                         |
| one-click-close-comments     | one-click-close-comments/one-click-close-comments.php |
| user-switching               | user-switching/user-switching.php                     |
| health-check-disable-plugins | health-check-disable-plugins.php                      |
+------------------------------+-------------------------------------------------------+

$ vendor/bin/wp plugin list --path='C:\\xampp\\htdocs\\cospol.local' --fields=name,slug,version
+------------------------------+-------------------------------------------------------+---------+
| name                         | slug                                                  | version |
+------------------------------+-------------------------------------------------------+---------+
| contact-form-7               | contact-form-7/wp-contact-form-7.php                  | 5.1.3   |
| health-check                 | health-check/health-check.php                         | 1.3.2   |
| one-click-close-comments     | one-click-close-comments/one-click-close-comments.php | 2.6     |
| user-switching               | user-switching/user-switching.php                     | 1.5.0   |
| health-check-disable-plugins | health-check-disable-plugins.php                      | 1.3     |
+------------------------------+-------------------------------------------------------+---------+
```

Thanks a lot.

#WCEU2019 #ContributorsDay