### PR TITLE
WP-CLI Themes: Added workaround to equalize folder naming conventions across Win/Mac/Linux

### DIFF
--- a/features/theme.feature
+++ b/features/theme.feature
@@ -547,10 +547,10 @@ Feature: Manage WordPress themes
   Scenario: Theme activation fails when slug does not match exactly
     Given a WP install
 
-    When I try `wp theme activate TwentySeventeen`
+    When I try `wp theme activate TwentyThirteen`
     Then STDERR should contain:
       """
-      Error: The 'TwentySeventeen' theme could not be found. Did you mean 'twentyseventeen'?
+      Error: The 'TwentyThirteen' theme could not be found. Did you mean 'twentythirteen'?
       """
     And STDOUT should be empty
     And the return code should be 1

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -547,10 +547,13 @@ Feature: Manage WordPress themes
   Scenario: Theme activation fails when slug does not match exactly
     Given a WP install
 
-    When I try `wp theme activate TwentyThirteen`
+    When I run `wp theme install p2`
+    Then the return code should be 0
+
+    When I try `wp theme activate P2`
     Then STDERR should contain:
       """
-      Error: The 'TwentyThirteen' theme could not be found. Did you mean 'twentythirteen'?
+      Error: The 'P2' theme could not be found. Did you mean 'p2'?
       """
     And STDOUT should be empty
     And the return code should be 1

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -557,3 +557,31 @@ Feature: Manage WordPress themes
       """
     And STDOUT should be empty
     And the return code should be 1
+
+    When I try `wp theme activate p3`
+    Then STDERR should contain:
+      """
+      Error: The 'p3' theme could not be found. Did you mean 'p2'?
+      """
+    And STDOUT should be empty
+    And the return code should be 1
+
+    When I try `wp theme activate pb2`
+    Then STDERR should contain:
+      """
+      Error: The 'pb2' theme could not be found. Did you mean 'p2'?
+      """
+    And STDOUT should be empty
+    And the return code should be 1
+
+    When I try `wp theme activate completelyoff`
+    Then STDERR should contain:
+      """
+      Error: The 'completelyoff' theme could not be found.
+      """
+    And STDERR should not contain:
+      """
+      Did you mean
+      """
+    And STDOUT should be empty
+    And the return code should be 1

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -543,3 +543,14 @@ Feature: Manage WordPress themes
        """
        active
        """
+
+  Scenario: Theme activation fails when slug does not match exactly
+    Given a WP install
+
+    When I try `wp theme activate TwentySeventeen`
+    Then STDERR should contain:
+      """
+      Error: The 'TwentySeventeen' theme could not be found.
+      """
+    And STDOUT should be empty
+    And the return code should be 1

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -550,7 +550,7 @@ Feature: Manage WordPress themes
     When I try `wp theme activate TwentySeventeen`
     Then STDERR should contain:
       """
-      Error: The 'TwentySeventeen' theme could not be found.
+      Error: The 'TwentySeventeen' theme could not be found. Did you mean 'twentyseventeen'?
       """
     And STDOUT should be empty
     And the return code should be 1

--- a/src/WP_CLI/Fetchers/Theme.php
+++ b/src/WP_CLI/Fetchers/Theme.php
@@ -2,6 +2,8 @@
 
 namespace WP_CLI\Fetchers;
 
+use WP_CLI\Utils;
+
 /**
  * Fetch a WordPress theme based on one of its attributes.
  */
@@ -46,11 +48,19 @@ class Theme extends Base {
 	 * @return string|boolean Case sensitive name if match found, otherwise false.
 	 */
 	private function find_inexact_match( $name, $existing_themes ) {
-		foreach ( $existing_themes as $key => $value ) {
-			if ( strtolower( $key ) === strtolower( $name ) ) {
-				return $key;
-			}
+		$target = strtolower( $name );
+		$themes = array_map( 'strtolower', array_keys( $existing_themes ) );
+
+		if ( in_array( $target, $themes, true ) ) {
+			return $target;
 		}
+
+		$suggestion = Utils\get_suggestion( $target, $themes );
+
+		if ( '' !== $suggestion ) {
+			return $suggestion;
+		}
+
 		return false;
 	}
 }

--- a/src/WP_CLI/Fetchers/Theme.php
+++ b/src/WP_CLI/Fetchers/Theme.php
@@ -42,7 +42,7 @@ class Theme extends Base {
 	 *
 	 * @param string $name Name of theme received by command.
 	 * @param array  $existing_themes Key/value pair of existing themes, key is
-	 *               a case sensitive name.
+	 *                                a case sensitive name.
 	 * @return string|boolean Case sensitive name if match found, otherwise false.
 	 */
 	private function find_inexact_match( $name, $existing_themes ) {

--- a/src/WP_CLI/Fetchers/Theme.php
+++ b/src/WP_CLI/Fetchers/Theme.php
@@ -19,7 +19,7 @@ class Theme extends Base {
 	 * @return object|false
 	 */
 	public function get( $name ) {
-		// Workaround to equalize folder naming conventions across Win/Mac/Linux
+		// Workaround to equalize folder naming conventions across Win/Mac/Linux.
 		// Returns false if theme stylesheet doesn't exactly match existing themes.
 		$existing_themes      = wp_get_themes( array( 'errors' => null ) );
 		$existing_stylesheets = array_keys( $existing_themes );

--- a/src/WP_CLI/Fetchers/Theme.php
+++ b/src/WP_CLI/Fetchers/Theme.php
@@ -21,7 +21,7 @@ class Theme extends Base {
 	public function get( $name ) {
 		// Workaround to equalize folder naming conventions across Win/Mac/Linux
 		// Returns false if theme stylesheet doesn't exactly match existing themes.
-		$existing_themes = wp_get_themes( array( 'errors' => null ) );
+		$existing_themes      = wp_get_themes( array( 'errors' => null ) );
 		$existing_stylesheets = array_keys( $existing_themes );
 		if ( ! in_array( $name, $existing_stylesheets, true ) ) {
 			return false;

--- a/src/WP_CLI/Fetchers/Theme.php
+++ b/src/WP_CLI/Fetchers/Theme.php
@@ -21,7 +21,7 @@ class Theme extends Base {
 	public function get( $name ) {
 		// Workaround to equalize folder naming conventions across Win/Mac/Linux
 		// Returns false if theme stylesheet doesn't exactly match existing themes.
-		$existing_themes = wp_get_themes();
+		$existing_themes = wp_get_themes( array( 'errors' => null ) );
 		$existing_stylesheets = array_keys( $existing_themes );
 		if ( ! in_array( $name, $existing_stylesheets, true ) ) {
 			return false;

--- a/src/WP_CLI/Fetchers/Theme.php
+++ b/src/WP_CLI/Fetchers/Theme.php
@@ -19,11 +19,15 @@ class Theme extends Base {
 	 * @return object|false
 	 */
 	public function get( $name ) {
-		$theme = wp_get_theme( $name );
-
-		if ( ! $theme->exists() ) {
+		// Workaround to equalize folder naming conventions across Win/Mac/Linux
+		// Returns false if theme stylesheet doesn't exactly match existing themes.
+		$existing_themes = wp_get_themes();
+		$existing_stylesheets = array_keys( $existing_themes );
+		if ( ! in_array( $name, $existing_stylesheets, true ) ) {
 			return false;
 		}
+
+		$theme = $existing_themes[ $name ];
 
 		return $theme;
 	}

--- a/src/WP_CLI/Fetchers/Theme.php
+++ b/src/WP_CLI/Fetchers/Theme.php
@@ -24,12 +24,34 @@ class Theme extends Base {
 		$existing_themes      = wp_get_themes( array( 'errors' => null ) );
 		$existing_stylesheets = array_keys( $existing_themes );
 		if ( ! in_array( $name, $existing_stylesheets, true ) ) {
+			$inexact_match = $this->find_inexact_match( $name, $existing_themes );
+			if ( false !== $inexact_match ) {
+				$this->msg .= sprintf( " Did you mean '%s'?", $inexact_match );
+			}
 			return false;
 		}
 
 		$theme = $existing_themes[ $name ];
 
 		return $theme;
+	}
+
+	/**
+	 * Find and return the key in $existing_themes that matches $name with
+	 * a case insensitive string comparison.
+	 *
+	 * @param string $name Name of theme received by command.
+	 * @param array  $existing_themes Key/value pair of existing themes, key is
+	 *               a case sensitive name.
+	 * @return string|boolean Case sensitive name if match found, otherwise false.
+	 */
+	private function find_inexact_match( $name, $existing_themes ) {
+		foreach ( $existing_themes as $key => $value ) {
+			if ( strtolower( $key ) === strtolower( $name ) ) {
+				return $key;
+			}
+		}
+		return false;
 	}
 }
 


### PR DESCRIPTION
- Test added and commits rebased on behalf of @achyuthajoy (PR #151)
- Fixes #121
- Error message when a case insensitive match exists has been improved:

```
wp theme delete P2
Error: The 'P2' theme could not be found. Did you mean 'p2'?
```
---

Modified Theme Fetcher to strict compare specified theme slug against existing ones as a Workaround to Operating System folder naming conventions.

This will equalize the non-lowercase slugs across all operating systems. If exact slug is not found, error is returned.

Fix to #121 - More info added to the bug report

--  @achyuthajoy 