### PR TITLE
Support multiple values on "plugin list --status=X" #194

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -309,6 +309,13 @@ Feature: Manage WordPress plugins
       | name       | status   | file                |
       | akismet    | active   | akismet/akismet.php |
 
+    When I run `wp plugin list --status=inactive,active --fields=name,status,file`
+    Then STDOUT should be a table containing rows:
+      | name        | status   | file                  |
+      | akismet     | active   | akismet/akismet.php   |
+      | hello-dolly | inactive | hello-dolly/hello.php |
+
+
   Scenario: Install a plugin when directory doesn't yet exist
     Given a WP install
 

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -486,8 +486,8 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			}
 
 			foreach ( $this->obj_fields as $field ) {
-                if ( 'status' === $field ) {
-                    $statuses = explode( ',', $assoc_args[ $field ] );
+				if ( 'status' === $field ) {
+					$statuses = explode( ',', $assoc_args[ $field ] );
 
 					foreach ( $statuses as $status ) {
 							$remove = false;
@@ -501,7 +501,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 					if ( $remove ) {
 						unset( $all_items[ $key ] );
 					}
-                }
+				}
 			}
 		}
 

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -486,7 +486,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			}
 
 			foreach ( $this->obj_fields as $field ) {
-				if ( 'status' === $field ) {
+				if ( isset( $assoc_args[ $field ] ) && ( 'status' === $field ) ) {
 					$statuses = explode( ',', $assoc_args[ $field ] );
 
 					foreach ( $statuses as $status ) {

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -486,21 +486,21 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			}
 
 			foreach ( $this->obj_fields as $field ) {
-                if ( 'status' == $field ) {
-                    $statuses = explode( ',',$assoc_args[ $field ] );
+                if ( 'status' === $field ) {
+                    $statuses = explode( ',', $assoc_args[ $field ] );
 
-                foreach ( $statuses as $status ) {
-                        $remove = false;
-                        if ( $item[$field] !== $status ) {
-                            $remove = true;
-                        } else {
-                            break;
-                        }
-                }
+					foreach ( $statuses as $status ) {
+							$remove = false;
+						if ( $item[ $field ] !== $status ) {
+							$remove = true;
+						} else {
+							break;
+						}
+					}
 
-                if ( $remove ) {
-                        unset( $all_items[$key] );
-                    }
+					if ( $remove ) {
+						unset( $all_items[ $key ] );
+					}
                 }
 			}
 		}

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -486,10 +486,22 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			}
 
 			foreach ( $this->obj_fields as $field ) {
-				if ( isset( $assoc_args[ $field ] )
-					&& $assoc_args[ $field ] !== $item[ $field ] ) {
-					unset( $all_items[ $key ] );
-				}
+                if ( 'status' == $field ) {
+                    $statuses = explode( ',',$assoc_args[ $field ] );
+
+                foreach ( $statuses as $status ) {
+                        $remove = false;
+                        if ( $item[$field] !== $status ) {
+                            $remove = true;
+                        } else {
+                            break;
+                        }
+                }
+
+                if ( $remove ) {
+                        unset( $all_items[$key] );
+                    }
+                }
 			}
 		}
 


### PR DESCRIPTION
Added support for multiple values in plugin list --status (e.g. wp plugin list --status=active,inactive"
