### PR TITLE
Add second must-use plugin that is added with wp-cli-tests 2.1.6+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "wp-cli/entity-command": "^1.3 || ^2",
         "wp-cli/scaffold-command": "^1.2 || ^2",
-        "wp-cli/wp-cli-tests": "^2.1"
+        "wp-cli/wp-cli-tests": "^2.1.6"
     },
     "config": {
         "process-timeout": 7200,

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -356,6 +356,7 @@ Feature: Manage WordPress plugins
       active
       active
       must-use
+      must-use
       """
 
     When I run `wp plugin deactivate --all`
@@ -377,6 +378,7 @@ Feature: Manage WordPress plugins
       """
       inactive
       inactive
+      must-use
       must-use
       """
 


### PR DESCRIPTION
A polyfills mu plugin was added to the tests framework and needs to be accounted for.