### PR TITLE
wp theme delete --all no longer errors on active theme deletion

### DIFF
--- a/features/theme-delete.feature
+++ b/features/theme-delete.feature
@@ -35,10 +35,11 @@ Feature: Delete WordPress themes
     And save STDOUT as {ACTIVE_THEME}
 
     When I try `wp theme delete --all`
-    Then STDERR should contain:
+    Then STDOUT should contain:
     """
-    Warning: Can't delete the currently active theme: {ACTIVE_THEME}
+    Success: Deleted
     """
+    And STDERR should be empty
 
     When I run `wp theme delete --all --force`
     Then STDOUT should be:

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -835,8 +835,10 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 			$theme_slug = $theme->get_stylesheet();
 
 			if ( $this->is_active_theme( $theme ) && ! $force ) {
-				WP_CLI::warning( "Can't delete the currently active theme: $theme_slug" );
-				$errors++;
+				if ( ! $all ) {
+					WP_CLI::warning( "Can't delete the currently active theme: $theme_slug" );
+					$errors++;
+				}
 				continue;
 			}
 


### PR DESCRIPTION
Fixes issue #217

I'm not sure if only testing on the "Success: Deleted" string is good enough, but i didn't want to assume there will always be 5 themes.
