### PR TITLE
Missing `--network` parameter for `plugin is-active`

### DIFF
--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -946,7 +946,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * : The plugin to check.
 	 *
 	 * [--network]
-	 * : If set, check if plugin is network-activated
+	 * : If set, check if plugin is network-activated.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -945,6 +945,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * <plugin>
 	 * : The plugin to check.
 	 *
+	 * [--network]
+	 * : If set, check if plugin is network-activated
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Check whether plugin is Active; exit status 0 if active, otherwise 1


### PR DESCRIPTION
The code checks for the argument "network" but its not possible to add it, since the cli fails because its not declered as a valid param.

This fix add's it as a argument.