### PR TITLE
Validate the status filter passed to `wp plugin list` and `wp theme list`

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -603,3 +603,19 @@ Feature: Manage WordPress plugins
     Warning: hello-dolly: version higher than expected.
     Error: No plugins updated.
     """
+
+  Scenario: Only valid status filters are accepted when listing plugins
+    Given a WP install
+
+    When I run `wp plugin list`
+    Then STDERR should be empty
+
+    When I run `wp plugin list --status=active`
+    Then STDERR should be empty
+
+    When I try `wp plugin list --status=invalid-status`
+    Then STDERR should be:
+      """
+      Error: Parameter errors:
+       Invalid value specified for 'status' (Filter the output by plugin status.)
+      """

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -585,3 +585,19 @@ Feature: Manage WordPress themes
       """
     And STDOUT should be empty
     And the return code should be 1
+
+  Scenario: Only valid status filters are accepted when listing themes
+    Given a WP install
+
+    When I run `wp theme list`
+    Then STDERR should be empty
+
+    When I run `wp theme list --status=active`
+    Then STDERR should be empty
+
+    When I try `wp theme list --status=invalid-status`
+    Then STDERR should be:
+      """
+      Error: Parameter errors:
+       Invalid value specified for 'status' (Filter the output by theme status.)
+      """

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1048,6 +1048,17 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *   - yaml
 	 * ---
 	 *
+	 * [--status=<status>]
+	 * : Filter the output by plugin status.
+	 * ---
+	 * options:
+	 *   - active
+	 *   - active-network
+	 *   - dropin
+	 *   - inactive
+	 *   - must-use
+	 * ---
+	 *
 	 * ## AVAILABLE FIELDS
 	 *
 	 * These fields will be displayed by default for each plugin:

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -883,6 +883,15 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	 *   - yaml
 	 * ---
 	 *
+	 * [--status=<status>]
+	 * : Filter the output by theme status.
+	 * ---
+	 * options:
+	 *   - active
+	 *   - parent
+	 *   - inactive
+	 * ---
+	 *
 	 * ## AVAILABLE FIELDS
 	 *
 	 * These fields will be displayed by default for each theme:


### PR DESCRIPTION
Added DocBlock changes to validate `status` values passed to `wp plugin list` and `wp theme list`.

Fixes https://github.com/wp-cli/extension-command/issues/215