### PR TITLE
[wp-cli#194] Allow for filtering my a multiple field values for the "list" subcommand. WIP.

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -309,6 +309,35 @@ Feature: Manage WordPress plugins
       | name       | status   | file                |
       | akismet    | active   | akismet/akismet.php |
 
+  Scenario: List plugin by multiple statuses
+    Given a WP multisite install
+    And a wp-content/plugins/network-only.php file:
+      """
+      // Plugin Name: Example Plugin
+      // Network: true
+      """
+
+    When I run `wp plugin activate akismet hello`
+    Then STDOUT should not be empty
+
+    When I run `wp plugin install wordpress-importer`
+    Then STDOUT should not be empty
+
+    When I run `wp plugin activate network-only`
+    Then STDOUT should not be empty
+
+    When I run `wp plugin list --status=network-active,inactive --fields=name,status,file`
+    Then STDOUT should be a table containing rows:
+      | name               | status         | file                                      |
+      | network-only       | network-active | network-only.php                          |
+      | wordpress-importer | inactive       | wordpress-importer/wordpress-importer.php |
+
+    When I run `wp plugin list --status=active,inactive --fields=name,status,file`
+    Then STDOUT should be a table containing rows:
+      | name               | status   | file                                      |
+      | akismet            | active   | akismet/akismet.php                       |
+      | wordpress-importer | inactive | wordpress-importer/wordpress-importer.php |
+
   Scenario: Install a plugin when directory doesn't yet exist
     Given a WP install
 

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -20,6 +20,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	const INVALID_VERSION_MESSAGE = 'version higher than expected';
 
 	public function __construct() {
+
 		// Do not automatically check translations updates after updating plugins/themes.
 		add_action(
 			'upgrader_process_complete',
@@ -486,8 +487,17 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			}
 
 			foreach ( $this->obj_fields as $field ) {
-				if ( isset( $assoc_args[ $field ] )
-					&& $assoc_args[ $field ] !== $item[ $field ] ) {
+				if ( ! array_key_exists( $field, $assoc_args ) ) {
+					continue;
+				}
+
+				// This can be either a value to filter by or a comma-separated list of values.
+				// Also, it is not forbidden for a value to contain a comma (in which case we can filter only by one).
+				$field_filter = $assoc_args[ $field ];
+				if (
+					$item[ $field ] !== $field_filter
+					&& ! in_array( $item[ $field ], array_map( 'trim', explode( ',', $field_filter ) ), true )
+				) {
 					unset( $all_items[ $key ] );
 				}
 			}


### PR DESCRIPTION
Fixes #194 

This impacts "plugin list" and "theme list" commands.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
