### PR TITLE
Provide clear error message when plugin fails PHP requirement

### DIFF
--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -81,6 +81,7 @@ Feature: Activate WordPress plugins
       Success: No plugins installed.
       """
 
+  @require-wp-5.2
   Scenario: Activating a plugin that does not meet PHP minimum throws a warning
     Given a wp-content/plugins/high-requirements.php file:
       """

--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -92,20 +92,14 @@ Feature: Activate WordPress plugins
        * Requires PHP: 99.99
        */
        """
-    And  I run `wp plugin deactivate --all`
+    And I run `wp plugin deactivate --all`
+    And I run `php -r 'echo PHP_VERSION;'`
+    And save STDOUT as {PHP_VERSION}
 
     When I try `wp plugin activate high-requirements`
     Then STDERR should contain:
       """
-      Failed to activate plugin
-      """
-    And STDERR should contain:
-      """
-      Current PHP version
-      """
-    And STDERR should contain:
-      """
-      does not meet minimum requirements
+      Failed to activate plugin. Current PHP version ({PHP_VERSION}) does not meet minimum requirements for High PHP Requirements. The plugin requires PHP 99.99.
       """
     And STDOUT should not contain:
       """

--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -80,3 +80,25 @@ Feature: Activate WordPress plugins
       """
       Success: No plugins installed.
       """
+
+  Scenario: Activating a plugin that does not meet PHP minimum throws a warning
+    Given a wp-content/plugins/high-requirements.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: High PHP Requirements
+       * Description: This is meant to not activate because PHP version is too low.
+       * Author: WP-CLI tests
+       * Requires PHP: 99.99
+       */
+       """
+
+    When I run `wp plugin activate high-requirements`
+    Then STDERR should contain:
+      """
+      Failed to activate plugin: PHP minimum not met.
+      """
+    And STDOUT should not contain:
+      """
+      1 out of 1
+      """

--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -92,11 +92,20 @@ Feature: Activate WordPress plugins
        * Requires PHP: 99.99
        */
        """
+    And  I run `wp plugin deactivate --all`
 
-    When I run `wp plugin activate high-requirements`
+    When I try `wp plugin activate high-requirements`
     Then STDERR should contain:
       """
-      Failed to activate plugin: PHP minimum not met.
+      Failed to activate plugin
+      """
+    And STDERR should contain:
+      """
+      Current PHP version
+      """
+    And STDERR should contain:
+      """
+      does not meet minimum requirements
       """
     And STDOUT should not contain:
       """

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -207,6 +207,7 @@ Feature: Manage WordPress plugins
     Given a WP multisite install
     And a wp-content/plugins/network-only.php file:
       """
+      <?php
       // Plugin Name: Example Plugin
       // Network: true
       """

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -185,6 +185,7 @@ Feature: Manage WordPress plugins
     Given a WP install
     And a wp-content/plugins/network-only.php file:
       """
+      <?php
       // Plugin Name: Example Plugin
       // Network: true
       """

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -539,7 +539,7 @@ Feature: Manage WordPress plugins
       """
     And the return code should be 0
 
-  @require-wp-47
+  @require-wp-4.7
   Scenario: Plugin hidden by "all_plugins" filter
     Given a WP install
     And these installed and active plugins:

--- a/src/Plugin_AutoUpdates_Command.php
+++ b/src/Plugin_AutoUpdates_Command.php
@@ -78,6 +78,9 @@ class Plugin_AutoUpdates_Command {
 		$disabled_only = Utils\get_flag_value( $assoc_args, 'disabled-only', false );
 
 		$args = $this->check_optional_args_and_all( $args, $all );
+		if ( ! $args ) {
+			return;
+		}
 
 		$plugins      = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
@@ -152,6 +155,9 @@ class Plugin_AutoUpdates_Command {
 		$enabled_only = Utils\get_flag_value( $assoc_args, 'enabled-only', false );
 
 		$args = $this->check_optional_args_and_all( $args, $all );
+		if ( ! $args ) {
+			return;
+		}
 
 		$plugins      = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -323,12 +323,13 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			$result = activate_plugin( $plugin->file, '', $network_wide );
 
 			if ( is_wp_error( $result ) ) {
-				WP_CLI::warning( "Failed to activate plugin: {$result->get_error_message()}" );
-			}
-
-			$this->active_output( $plugin->name, $plugin->file, $network_wide, 'activate' );
-
-			if ( ! is_wp_error( $result ) ) {
+				$message = $result->get_error_message();
+				$message = preg_replace( '/<a\s[^>]+>.*<\/a>/im', '', $message );
+				$message = strip_tags( $message );
+				$message = str_replace( 'Error: ', '', $message );
+				WP_CLI::warning( "Failed to activate plugin. {$message}" );
+			} else {
+				$this->active_output( $plugin->name, $plugin->file, $network_wide, 'activate' );
 				$successes++;
 			}
 		}

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -320,10 +320,17 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				deactivate_plugins( $plugin->file, false, false );
 			}
 
-			activate_plugin( $plugin->file, '', $network_wide );
+			$result = activate_plugin( $plugin->file, '', $network_wide );
+
+			if ( is_wp_error( $result ) ) {
+				WP_CLI::warning( "Failed to activate plugin: {$result->get_error_message()}" );
+			}
 
 			$this->active_output( $plugin->name, $plugin->file, $network_wide, 'activate' );
-			$successes++;
+
+			if ( ! is_wp_error( $result ) ) {
+				$successes++;
+			}
 		}
 
 		if ( ! $this->chained_command ) {

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -325,7 +325,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			if ( is_wp_error( $result ) ) {
 				$message = $result->get_error_message();
 				$message = preg_replace( '/<a\s[^>]+>.*<\/a>/im', '', $message );
-				$message = strip_tags( $message );
+				$message = wp_strip_all_tags( $message );
 				$message = str_replace( 'Error: ', '', $message );
 				WP_CLI::warning( "Failed to activate plugin. {$message}" );
 			} else {

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -299,6 +299,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		$all          = Utils\get_flag_value( $assoc_args, 'all', false );
 
 		$args = $this->check_optional_args_and_all( $args, $all );
+		if ( ! $args ) {
+			return;
+		}
 
 		$successes = 0;
 		$errors    = 0;
@@ -377,6 +380,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		$disable_all  = Utils\get_flag_value( $assoc_args, 'all' );
 
 		$args = $this->check_optional_args_and_all( $args, $disable_all );
+		if ( ! $args ) {
+			return;
+		}
 
 		$successes = 0;
 		$errors    = 0;
@@ -639,6 +645,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		$all = Utils\get_flag_value( $assoc_args, 'all', false );
 
 		$args = $this->check_optional_args_and_all( $args, $all );
+		if ( ! $args ) {
+			return;
+		}
 
 		if ( isset( $assoc_args['version'] ) ) {
 			foreach ( $this->fetcher->get_many( $args ) as $plugin ) {
@@ -878,6 +887,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 		// Check if plugin names or --all is passed.
 		$args = $this->check_optional_args_and_all( $args, $all, 'uninstall' );
+		if ( ! $args ) {
+			return;
+		}
 
 		$successes = 0;
 		$errors    = 0;
@@ -1003,6 +1015,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 		// Check if plugin names or --all is passed.
 		$args = $this->check_optional_args_and_all( $args, $all, 'delete' );
+		if ( ! $args ) {
+			return;
+		}
 
 		$successes = 0;
 		$errors    = 0;

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -299,9 +299,6 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		$all          = Utils\get_flag_value( $assoc_args, 'all', false );
 
 		$args = $this->check_optional_args_and_all( $args, $all );
-		if ( ! $args ) {
-			return;
-		}
 
 		$successes = 0;
 		$errors    = 0;
@@ -380,9 +377,6 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		$disable_all  = Utils\get_flag_value( $assoc_args, 'all' );
 
 		$args = $this->check_optional_args_and_all( $args, $disable_all );
-		if ( ! $args ) {
-			return;
-		}
 
 		$successes = 0;
 		$errors    = 0;
@@ -645,9 +639,6 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		$all = Utils\get_flag_value( $assoc_args, 'all', false );
 
 		$args = $this->check_optional_args_and_all( $args, $all );
-		if ( ! $args ) {
-			return;
-		}
 
 		if ( isset( $assoc_args['version'] ) ) {
 			foreach ( $this->fetcher->get_many( $args ) as $plugin ) {
@@ -885,11 +876,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 		$all = Utils\get_flag_value( $assoc_args, 'all', false );
 
-		// Check if plugin names of --all is passed.
+		// Check if plugin names or --all is passed.
 		$args = $this->check_optional_args_and_all( $args, $all, 'uninstall' );
-		if ( ! $args ) {
-			return;
-		}
 
 		$successes = 0;
 		$errors    = 0;
@@ -1013,11 +1001,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	public function delete( $args, $assoc_args = array() ) {
 		$all = Utils\get_flag_value( $assoc_args, 'all', false );
 
-		// Check if plugin names of --all is passed.
+		// Check if plugin names or --all is passed.
 		$args = $this->check_optional_args_and_all( $args, $all, 'delete' );
-		if ( ! $args ) {
-			return;
-		}
 
 		$successes = 0;
 		$errors    = 0;

--- a/src/Theme_AutoUpdates_Command.php
+++ b/src/Theme_AutoUpdates_Command.php
@@ -78,6 +78,9 @@ class Theme_AutoUpdates_Command {
 		$disabled_only = Utils\get_flag_value( $assoc_args, 'disabled-only', false );
 
 		$args = $this->check_optional_args_and_all( $args, $all );
+		if ( ! $args ) {
+			return;
+		}
 
 		$themes       = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
@@ -152,6 +155,9 @@ class Theme_AutoUpdates_Command {
 		$enabled_only = Utils\get_flag_value( $assoc_args, 'enabled-only', false );
 
 		$args = $this->check_optional_args_and_all( $args, $all );
+		if ( ! $args ) {
+			return;
+		}
 
 		$themes       = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -647,9 +647,6 @@ class Theme_Command extends CommandWithUpgrade {
 		$all = Utils\get_flag_value( $assoc_args, 'all', false );
 
 		$args = $this->check_optional_args_and_all( $args, $all );
-		if ( ! $args ) {
-			return;
-		}
 
 		if ( isset( $assoc_args['version'] ) && isset( $assoc_args['dry-run'] ) ) {
 			WP_CLI::error( '--dry-run cannot be used together with --version.' );
@@ -757,9 +754,6 @@ class Theme_Command extends CommandWithUpgrade {
 		$all = Utils\get_flag_value( $assoc_args, 'all', false );
 
 		$args = $this->check_optional_args_and_all( $args, $all, 'delete' );
-		if ( ! $args ) {
-			return;
-		}
 
 		$force = Utils\get_flag_value( $assoc_args, 'force', false );
 

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -647,6 +647,9 @@ class Theme_Command extends CommandWithUpgrade {
 		$all = Utils\get_flag_value( $assoc_args, 'all', false );
 
 		$args = $this->check_optional_args_and_all( $args, $all );
+		if ( ! $args ) {
+			return;
+		}
 
 		if ( isset( $assoc_args['version'] ) && isset( $assoc_args['dry-run'] ) ) {
 			WP_CLI::error( '--dry-run cannot be used together with --version.' );
@@ -754,6 +757,9 @@ class Theme_Command extends CommandWithUpgrade {
 		$all = Utils\get_flag_value( $assoc_args, 'all', false );
 
 		$args = $this->check_optional_args_and_all( $args, $all, 'delete' );
+		if ( ! $args ) {
+			return;
+		}
 
 		$force = Utils\get_flag_value( $assoc_args, 'force', false );
 


### PR DESCRIPTION
If you try to activate a plugin that doesn't meet the minimum PHP requirements, WP-CLI now tells you the specific reason why it is failing, instead of giving a generic error message and then showing a success message as well.

Fixes #251

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->