### PR TITLE
Add commands to manage auto-updates for plugins and themes

### DIFF
--- a/extension-command.php
+++ b/extension-command.php
@@ -10,5 +10,6 @@ if ( file_exists( $wpcli_extension_autoloader ) ) {
 }
 
 WP_CLI::add_command( 'plugin', 'Plugin_Command' );
+WP_CLI::add_command( 'plugin auto-updates', 'Plugin_AutoUpdates_Command' );
 WP_CLI::add_command( 'theme', 'Theme_Command' );
 WP_CLI::add_command( 'theme mod', 'Theme_Mod_Command' );

--- a/extension-command.php
+++ b/extension-command.php
@@ -12,4 +12,5 @@ if ( file_exists( $wpcli_extension_autoloader ) ) {
 WP_CLI::add_command( 'plugin', 'Plugin_Command' );
 WP_CLI::add_command( 'plugin auto-updates', 'Plugin_AutoUpdates_Command' );
 WP_CLI::add_command( 'theme', 'Theme_Command' );
+WP_CLI::add_command( 'theme auto-updates', 'Theme_AutoUpdates_Command' );
 WP_CLI::add_command( 'theme mod', 'Theme_Mod_Command' );

--- a/features/plugin-auto-updates-disable.feature
+++ b/features/plugin-auto-updates-disable.feature
@@ -1,0 +1,76 @@
+Feature: Disable auto-updates for WordPress plugins
+
+  Background:
+    Given a WP install
+    And I run `wp plugin install duplicate-post`
+    And I run `wp plugin auto-updates enable --all`
+
+  Scenario: Show an error if required params are missing
+    When I try `wp plugin auto-updates disable`
+    Then STDOUT should be empty
+    And STDERR should contain:
+      """
+      Error: Please specify one or more plugins, or use --all.
+      """
+
+  Scenario: Disable auto-updates for a single plugin
+    When I run `wp plugin auto-updates disable hello`
+    Then STDOUT should be:
+      """
+      Success: Disabled 1 of 1 plugin auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Disable auto-updates for multiple plugins
+    When I run `wp plugin auto-updates disable hello duplicate-post`
+    Then STDOUT should be:
+      """
+      Success: Disabled 2 of 2 plugin auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Disable auto-updates for all plugins
+    When I run `wp plugin auto-updates disable --all`
+    Then STDOUT should be:
+      """
+      Success: Disabled 3 of 3 plugin auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Disable auto-updates for already disabled plugins
+    When I run `wp plugin auto-updates disable hello`
+    And I try `wp plugin auto-updates disable --all`
+    Then STDERR should contain:
+      """
+      Warning: Auto-updates already disabled for plugin hello.
+      """
+    And STDERR should contain:
+      """
+      Error: Only disabled 2 of 3 plugin auto-updates.
+      """
+
+  Scenario: Filter when enabling auto-updates for already disabled plugins
+    When I run `wp plugin auto-updates disable hello`
+    And I run `wp plugin auto-updates disable --all --enabled-only`
+    Then STDOUT should be:
+      """
+      Success: Disabled 2 of 2 plugin auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Filter when enabling auto-updates for already disabled selection of plugins
+    When I run `wp plugin auto-updates disable hello`
+    And I run `wp plugin auto-updates disable hello duplicate-post --enabled-only`
+    Then STDOUT should be:
+      """
+      Success: Disabled 1 of 1 plugin auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Filtering everything away produces an error
+    When I run `wp plugin auto-updates disable hello`
+    And I try `wp plugin auto-updates disable hello --enabled-only`
+    Then STDERR should be:
+      """
+      Error: No plugins provided to disable auto-updates for.
+      """

--- a/features/plugin-auto-updates-enable.feature
+++ b/features/plugin-auto-updates-enable.feature
@@ -1,0 +1,75 @@
+Feature: Enable auto-updates for WordPress plugins
+
+  Background:
+    Given a WP install
+    And I run `wp plugin install duplicate-post`
+
+  Scenario: Show an error if required params are missing
+    When I try `wp plugin auto-updates enable`
+    Then STDOUT should be empty
+    And STDERR should contain:
+      """
+      Error: Please specify one or more plugins, or use --all.
+      """
+
+  Scenario: Enable auto-updates for a single plugin
+    When I run `wp plugin auto-updates enable hello`
+    Then STDOUT should be:
+      """
+      Success: Enabled 1 of 1 plugin auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Enable auto-updates for multiple plugins
+    When I run `wp plugin auto-updates enable hello duplicate-post`
+    Then STDOUT should be:
+      """
+      Success: Enabled 2 of 2 plugin auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Enable auto-updates for all plugins
+    When I run `wp plugin auto-updates enable --all`
+    Then STDOUT should be:
+      """
+      Success: Enabled 3 of 3 plugin auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Enable auto-updates for already enabled plugins
+    When I run `wp plugin auto-updates enable hello`
+    And I try `wp plugin auto-updates enable --all`
+    Then STDERR should contain:
+      """
+      Warning: Auto-updates already enabled for plugin hello.
+      """
+    And STDERR should contain:
+      """
+      Error: Only enabled 2 of 3 plugin auto-updates.
+      """
+
+  Scenario: Filter when enabling auto-updates for already enabled plugins
+    When I run `wp plugin auto-updates enable hello`
+    And I run `wp plugin auto-updates enable --all --disabled-only`
+    Then STDOUT should be:
+      """
+      Success: Enabled 2 of 2 plugin auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Filter when enabling auto-updates for already enabled selection of plugins
+    When I run `wp plugin auto-updates enable hello`
+    And I run `wp plugin auto-updates enable hello duplicate-post --disabled-only`
+    Then STDOUT should be:
+      """
+      Success: Enabled 1 of 1 plugin auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Filtering everything away produces an error
+    When I run `wp plugin auto-updates enable hello`
+    And I try `wp plugin auto-updates enable hello --disabled-only`
+    Then STDERR should be:
+      """
+      Error: No plugins provided to enable auto-updates for.
+      """

--- a/features/plugin-auto-updates-status.feature
+++ b/features/plugin-auto-updates-status.feature
@@ -1,0 +1,93 @@
+Feature: Show the status of auto-updates for WordPress plugins
+
+  Background:
+    Given a WP install
+    And I run `wp plugin install duplicate-post`
+
+  Scenario: Show an error if required params are missing
+    When I try `wp plugin auto-updates status`
+    Then STDOUT should be empty
+    And STDERR should contain:
+      """
+      Error: Please specify one or more plugins, or use --all.
+      """
+
+  Scenario: Show the status of auto-updates of a single plugin
+    When I run `wp plugin auto-updates status hello`
+    Then STDOUT should be a table containing rows:
+      | name           | status   |
+      | hello          | disabled |
+    And the return code should be 0
+
+  Scenario: Show the status of auto-updates multiple plugins
+    When I run `wp plugin auto-updates status duplicate-post hello`
+    Then STDOUT should be a table containing rows:
+      | name           | status   |
+      | duplicate-post | disabled |
+      | hello          | disabled |
+    And the return code should be 0
+
+  Scenario: Show the status of auto-updates all installed plugins
+    When I run `wp plugin auto-updates status --all`
+    Then STDOUT should be a table containing rows:
+      | name           | status   |
+      | akismet        | disabled |
+      | duplicate-post | disabled |
+      | hello          | disabled |
+    And the return code should be 0
+
+    When I run `wp plugin auto-updates enable --all`
+    And I run `wp plugin auto-updates status --all`
+    Then STDOUT should be a table containing rows:
+      | name           | status   |
+      | akismet        | enabled  |
+      | duplicate-post | enabled  |
+      | hello          | enabled  |
+    And the return code should be 0
+
+  Scenario: The status can be filtered to only show enabled or disabled plugins
+    Given I run `wp plugin auto-updates enable hello`
+
+    When I run `wp plugin auto-updates status --all`
+    Then STDOUT should be a table containing rows:
+      | name           | status   |
+      | akismet        | disabled |
+      | duplicate-post | disabled |
+      | hello          | enabled |
+    And the return code should be 0
+
+    When I run `wp plugin auto-updates status --all --enabled-only`
+    Then STDOUT should be a table containing rows:
+      | name           | status   |
+      | hello          | enabled |
+    And the return code should be 0
+
+    When I run `wp plugin auto-updates status --all --disabled-only`
+    Then STDOUT should be a table containing rows:
+      | name           | status   |
+      | akismet        | disabled |
+      | duplicate-post | disabled |
+    And the return code should be 0
+
+    When I try `wp plugin auto-updates status --all --enabled-only --disabled-only`
+    Then STDOUT should be empty
+    And STDERR should contain:
+      """
+      Error: --enabled-only and --disabled-only are mutually exclusive and cannot be used at the same time.
+      """
+
+  Scenario: The fields can be shown individually
+    Given I run `wp plugin auto-updates enable hello`
+
+    When I run `wp plugin auto-updates status --all --disabled-only --field=name`
+    Then STDOUT should be:
+      """
+      akismet
+      duplicate-post
+      """
+
+    When I run `wp plugin auto-updates status hello --field=status`
+    Then STDOUT should be:
+      """
+      enabled
+      """

--- a/features/plugin-auto-updates-status.feature
+++ b/features/plugin-auto-updates-status.feature
@@ -53,13 +53,13 @@ Feature: Show the status of auto-updates for WordPress plugins
       | name           | status   |
       | akismet        | disabled |
       | duplicate-post | disabled |
-      | hello          | enabled |
+      | hello          | enabled  |
     And the return code should be 0
 
     When I run `wp plugin auto-updates status --all --enabled-only`
     Then STDOUT should be a table containing rows:
       | name           | status   |
-      | hello          | enabled |
+      | hello          | enabled  |
     And the return code should be 0
 
     When I run `wp plugin auto-updates status --all --disabled-only`

--- a/features/theme-auto-update-status.feature
+++ b/features/theme-auto-update-status.feature
@@ -1,0 +1,96 @@
+Feature: Show the status of auto-updates for WordPress themes
+
+  Background:
+    Given a WP install
+    And I run `wp theme delete --all --force`
+    And I run `wp theme install twentysixteen`
+    And I run `wp theme install twentyseventeen`
+    And I run `wp theme install twentynineteen`
+
+  Scenario: Show an error if required params are missing
+    When I try `wp theme auto-updates status`
+    Then STDOUT should be empty
+    And STDERR should contain:
+      """
+      Error: Please specify one or more themes, or use --all.
+      """
+
+  Scenario: Show the status of auto-updates of a single theme
+    When I run `wp theme auto-updates status twentysixteen`
+    Then STDOUT should be a table containing rows:
+      | name            | status   |
+      | twentysixteen   | disabled |
+    And the return code should be 0
+
+  Scenario: Show the status of auto-updates multiple themes
+    When I run `wp theme auto-updates status twentyseventeen twentysixteen`
+    Then STDOUT should be a table containing rows:
+      | name            | status   |
+      | twentyseventeen | disabled |
+      | twentysixteen   | disabled |
+    And the return code should be 0
+
+  Scenario: Show the status of auto-updates all installed themes
+    When I run `wp theme auto-updates status --all`
+    Then STDOUT should be a table containing rows:
+      | name            | status   |
+      | twentynineteen  | disabled |
+      | twentyseventeen | disabled |
+      | twentysixteen   | disabled |
+    And the return code should be 0
+
+    When I run `wp theme auto-updates enable --all`
+    And I run `wp theme auto-updates status --all`
+    Then STDOUT should be a table containing rows:
+      | name            | status   |
+      | twentynineteen  | enabled  |
+      | twentyseventeen | enabled  |
+      | twentysixteen   | enabled  |
+    And the return code should be 0
+
+  Scenario: The status can be filtered to only show enabled or disabled themes
+    Given I run `wp theme auto-updates enable twentysixteen`
+
+    When I run `wp theme auto-updates status --all`
+    Then STDOUT should be a table containing rows:
+      | name            | status   |
+      | twentynineteen  | disabled |
+      | twentyseventeen | disabled |
+      | twentysixteen   | enabled  |
+    And the return code should be 0
+
+    When I run `wp theme auto-updates status --all --enabled-only`
+    Then STDOUT should be a table containing rows:
+      | name            | status   |
+      | twentysixteen   | enabled  |
+    And the return code should be 0
+
+    When I run `wp theme auto-updates status --all --disabled-only`
+    Then STDOUT should be a table containing rows:
+      | name            | status   |
+      | twentynineteen  | disabled |
+      | twentyseventeen | disabled |
+    And the return code should be 0
+
+    When I try `wp theme auto-updates status --all --enabled-only --disabled-only`
+    Then STDOUT should be empty
+    And STDERR should contain:
+      """
+      Error: --enabled-only and --disabled-only are mutually exclusive and cannot be used at the same time.
+      """
+
+  Scenario: The fields can be shown individually
+    Given I run `wp theme auto-updates enable twentysixteen`
+
+    When I run `wp theme auto-updates status --all --disabled-only --field=name`
+    Then STDOUT should be:
+      """
+      twentynineteen
+      twentyseventeen
+      """
+
+    When I run `wp theme auto-updates status twentysixteen --field=status`
+    Then STDOUT should be:
+      """
+      enabled
+      """

--- a/features/theme-auto-updates-disable.feature
+++ b/features/theme-auto-updates-disable.feature
@@ -1,0 +1,79 @@
+Feature: Disable auto-updates for WordPress themes
+
+  Background:
+    Given a WP install
+    And I run `wp theme delete --all --force`
+    And I run `wp theme install twentysixteen`
+    And I run `wp theme install twentyseventeen`
+    And I run `wp theme install twentynineteen`
+    And I try `wp theme auto-updates enable --all`
+
+  Scenario: Show an error if required params are missing
+    When I try `wp theme auto-updates disable`
+    Then STDOUT should be empty
+    And STDERR should contain:
+      """
+      Error: Please specify one or more themes, or use --all.
+      """
+
+  Scenario: Disable auto-updates for a single theme
+    When I run `wp theme auto-updates disable twentysixteen`
+    Then STDOUT should be:
+      """
+      Success: Disabled 1 of 1 theme auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Disable auto-updates for multiple themes
+    When I run `wp theme auto-updates disable twentysixteen twentyseventeen`
+    Then STDOUT should be:
+      """
+      Success: Disabled 2 of 2 theme auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Disable auto-updates for all themes
+    When I run `wp theme auto-updates disable --all`
+    Then STDOUT should be:
+      """
+      Success: Disabled 3 of 3 theme auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Disable auto-updates for already disabled themes
+    When I run `wp theme auto-updates disable twentysixteen`
+    And I try `wp theme auto-updates disable --all`
+    Then STDERR should contain:
+      """
+      Warning: Auto-updates already disabled for theme twentysixteen.
+      """
+    And STDERR should contain:
+      """
+      Error: Only disabled 2 of 3 theme auto-updates.
+      """
+
+  Scenario: Filter when enabling auto-updates for already disabled themes
+    When I run `wp theme auto-updates disable twentysixteen`
+    And I run `wp theme auto-updates disable --all --enabled-only`
+    Then STDOUT should be:
+      """
+      Success: Disabled 2 of 2 theme auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Filter when enabling auto-updates for already disabled selection of themes
+    When I run `wp theme auto-updates disable twentysixteen`
+    And I run `wp theme auto-updates disable twentysixteen twentyseventeen --enabled-only`
+    Then STDOUT should be:
+      """
+      Success: Disabled 1 of 1 theme auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Filtering everything away produces an error
+    When I run `wp theme auto-updates disable twentysixteen`
+    And I try `wp theme auto-updates disable twentysixteen --enabled-only`
+    Then STDERR should be:
+      """
+      Error: No themes provided to disable auto-updates for.
+      """

--- a/features/theme-auto-updates-enable.feature
+++ b/features/theme-auto-updates-enable.feature
@@ -1,0 +1,79 @@
+Feature: Enable auto-updates for WordPress themes
+
+  Background:
+    Given a WP install
+    And I run `wp theme delete --all --force`
+    And I run `wp theme install twentysixteen`
+    And I run `wp theme install twentyseventeen`
+    And I run `wp theme install twentynineteen`
+    And I try `wp theme auto-updates disable --all`
+
+  Scenario: Show an error if required params are missing
+    When I try `wp theme auto-updates enable`
+    Then STDOUT should be empty
+    And STDERR should contain:
+      """
+      Error: Please specify one or more themes, or use --all.
+      """
+
+  Scenario: Enable auto-updates for a single theme
+    When I run `wp theme auto-updates enable twentysixteen`
+    Then STDOUT should be:
+      """
+      Success: Enabled 1 of 1 theme auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Enable auto-updates for multiple themes
+    When I run `wp theme auto-updates enable twentysixteen twentyseventeen`
+    Then STDOUT should be:
+      """
+      Success: Enabled 2 of 2 theme auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Enable auto-updates for all themes
+    When I run `wp theme auto-updates enable --all`
+    Then STDOUT should be:
+      """
+      Success: Enabled 3 of 3 theme auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Enable auto-updates for already enabled themes
+    When I run `wp theme auto-updates enable twentysixteen`
+    And I try `wp theme auto-updates enable --all`
+    Then STDERR should contain:
+      """
+      Warning: Auto-updates already enabled for theme twentysixteen.
+      """
+    And STDERR should contain:
+      """
+      Error: Only enabled 2 of 3 theme auto-updates.
+      """
+
+  Scenario: Filter when enabling auto-updates for already enabled themes
+    When I run `wp theme auto-updates enable twentysixteen`
+    And I run `wp theme auto-updates enable --all --disabled-only`
+    Then STDOUT should be:
+      """
+      Success: Enabled 2 of 2 theme auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Filter when enabling auto-updates for already enabled selection of themes
+    When I run `wp theme auto-updates enable twentysixteen`
+    And I run `wp theme auto-updates enable twentysixteen twentyseventeen --disabled-only`
+    Then STDOUT should be:
+      """
+      Success: Enabled 1 of 1 theme auto-updates.
+      """
+    And the return code should be 0
+
+  Scenario: Filtering everything away produces an error
+    When I run `wp theme auto-updates enable twentysixteen`
+    And I try `wp theme auto-updates enable twentysixteen --disabled-only`
+    Then STDERR should be:
+      """
+      Error: No themes provided to enable auto-updates for.
+      """

--- a/features/theme-delete.feature
+++ b/features/theme-delete.feature
@@ -51,7 +51,7 @@ Feature: Delete WordPress themes
     When I try the previous command again
     Then STDOUT should be:
     """
-    Success: No themes installed.
+    Success: No themes deleted.
     """
 
   Scenario: Attempting to delete a theme that doesn't exist

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -53,13 +53,14 @@
 
 	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
-		<exclude-pattern>*/src/(Plugin_|Theme_(Mod_)?)Command\.php$</exclude-pattern>
+		<exclude-pattern>*/src/(Plugin_|Plugin_AutoUpdates_|Theme_(Mod_)?)Command\.php$</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound">
 		<exclude-pattern>*/src/WP_CLI/Fetchers/(Plugin|Theme)\.php$</exclude-pattern>
 		<exclude-pattern>*/src/WP_CLI/CommandWithUpgrade\.php$</exclude-pattern>
 		<exclude-pattern>*/src/WP_CLI/(CommandWith|DestructivePlugin|DestructiveTheme)Upgrader\.php$</exclude-pattern>
+		<exclude-pattern>*/src/WP_CLI/ParsePluginNameInput\.php$</exclude-pattern>
 	</rule>
 
 	<!-- Exclude classes from UselessOverridingMethod sniff as the method is used for generating docs. -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -53,14 +53,14 @@
 
 	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
-		<exclude-pattern>*/src/(Plugin_|Plugin_AutoUpdates_|Theme_(Mod_)?)Command\.php$</exclude-pattern>
+		<exclude-pattern>*/src/(Plugin_(AutoUpdates_)?|Theme_(Mod_|AutoUpdates_)?)Command\.php$</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound">
 		<exclude-pattern>*/src/WP_CLI/Fetchers/(Plugin|Theme)\.php$</exclude-pattern>
 		<exclude-pattern>*/src/WP_CLI/CommandWithUpgrade\.php$</exclude-pattern>
 		<exclude-pattern>*/src/WP_CLI/(CommandWith|DestructivePlugin|DestructiveTheme)Upgrader\.php$</exclude-pattern>
-		<exclude-pattern>*/src/WP_CLI/ParsePluginNameInput\.php$</exclude-pattern>
+		<exclude-pattern>*/src/WP_CLI/Parse(Plugin|Theme)NameInput\.php$</exclude-pattern>
 	</rule>
 
 	<!-- Exclude classes from UselessOverridingMethod sniff as the method is used for generating docs. -->

--- a/src/Plugin_AutoUpdates_Command.php
+++ b/src/Plugin_AutoUpdates_Command.php
@@ -1,0 +1,290 @@
+<?php
+
+use WP_CLI\Fetchers\Plugin;
+use WP_CLI\Formatter;
+use WP_CLI\ParsePluginNameInput;
+use WP_CLI\Utils;
+
+/**
+ * Manages plugin auto-updates.
+ *
+ * ## EXAMPLES
+ *
+ *     # Enable the auto-updates for a plugin
+ *     $ wp plugin auto-updates enable activate hello
+ *     Plugin auto-updates for 'hello' enabled.
+ *     Success: Enabled 1 of 1 plugin auto-updates.
+ *
+ *     # Disable the auto-updates for a plugin
+ *     $ wp plugin auto-updates disable activate hello
+ *     Plugin auto-updates for 'hello' disabled.
+ *     Success: Disabled 1 of 1 plugin auto-updates.
+ *
+ *     # Get the status of plugin auto-updates
+ *     $ wp plugin auto-updates status hello
+ *     Auto-updates for plugin 'hello' are disabled.
+ *
+ * @package wp-cli
+ */
+class Plugin_AutoUpdates_Command {
+
+	use ParsePluginNameInput;
+
+	/**
+	 * Site option that stores the status of plugin auto-updates.
+	 *
+	 * @var string
+	 */
+	const SITE_OPTION = 'auto_update_plugins';
+
+	/**
+	 * Plugin fetcher instance.
+	 *
+	 * @var Plugin
+	 */
+	protected $fetcher;
+
+	/**
+	 * Plugin_AutoUpdates_Command constructor.
+	 */
+	public function __construct() {
+		$this->fetcher = new Plugin();
+	}
+
+	/**
+	 * Enables the auto-updates for a plugin.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<plugin>...]
+	 * : One or more plugins to enable auto-updates for.
+	 *
+	 * [--all]
+	 * : If set, auto-updates will be enabled for all plugins.
+	 *
+	 * [--disabled-only]
+	 * : If set, filters list of plugins to only include the ones that have
+	 * auto-updates disabled.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Enable the auto-updates for a plugin
+	 *     $ wp plugin auto-updates enable activate hello
+	 *     Plugin auto-updates for 'hello' enabled.
+	 *     Success: Enabled 1 of 1 plugin auto-updates.
+	 */
+	public function enable( $args, $assoc_args ) {
+		$all           = Utils\get_flag_value( $assoc_args, 'all', false );
+		$disabled_only = Utils\get_flag_value( $assoc_args, 'disabled-only', false );
+
+		$args = $this->check_optional_args_and_all( $args, $all );
+
+		$plugins      = $this->fetcher->get_many( $args );
+		$auto_updates = get_site_option( static::SITE_OPTION );
+
+		if ( false === $auto_updates ) {
+			$auto_updates = [];
+		}
+
+		$count     = 0;
+		$successes = 0;
+
+		foreach ( $plugins as $plugin ) {
+			$enabled = in_array( $plugin->file, $auto_updates, true );
+
+			if ( $disabled_only && $enabled ) {
+				continue;
+			}
+
+			$count++;
+
+			if ( $enabled ) {
+				WP_CLI::warning(
+					"Auto-updates already enabled for plugin {$plugin->name}."
+				);
+			} else {
+				$auto_updates[] = $plugin->file;
+				$successes++;
+			}
+		}
+
+		if ( 0 === $count ) {
+			WP_CLI::error(
+				'No plugins provided to enable auto-updates for.'
+			);
+		}
+
+		update_site_option( static::SITE_OPTION, $auto_updates );
+
+		Utils\report_batch_operation_results(
+			'plugin auto-update',
+			'enable',
+			$count,
+			$successes,
+			$count - $successes
+		);
+	}
+
+	/**
+	 * Disables the auto-updates for a plugin.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<plugin>...]
+	 * : One or more plugins to disable auto-updates for.
+	 *
+	 * [--all]
+	 * : If set, auto-updates will be disabled for all plugins.
+	 *
+	 * [--enabled-only]
+	 * : If set, filters list of plugins to only include the ones that have
+	 * auto-updates enabled.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Disable the auto-updates for a plugin
+	 *     $ wp plugin auto-updates disable activate hello
+	 *     Plugin auto-updates for 'hello' disabled.
+	 *     Success: Disabled 1 of 1 plugin auto-updates.
+	 */
+	public function disable( $args, $assoc_args ) {
+		$all          = Utils\get_flag_value( $assoc_args, 'all', false );
+		$enabled_only = Utils\get_flag_value( $assoc_args, 'enabled-only', false );
+
+		$args = $this->check_optional_args_and_all( $args, $all );
+
+		$plugins      = $this->fetcher->get_many( $args );
+		$auto_updates = get_site_option( static::SITE_OPTION );
+
+		if ( false === $auto_updates ) {
+			$auto_updates = [];
+		}
+
+		$count     = 0;
+		$successes = 0;
+
+		foreach ( $plugins as $plugin ) {
+			$enabled = in_array( $plugin->file, $auto_updates, true );
+
+			if ( $enabled_only && ! $enabled ) {
+				continue;
+			}
+
+			$count++;
+
+			if ( ! $enabled ) {
+				WP_CLI::warning(
+					"Auto-updates already disabled for plugin {$plugin->name}."
+				);
+			} else {
+				$auto_updates = array_diff( $auto_updates, [ $plugin->file ] );
+				$successes++;
+			}
+		}
+
+		if ( 0 === $count ) {
+			WP_CLI::error(
+				'No plugins provided to disable auto-updates for.'
+			);
+		}
+
+		if ( count( $auto_updates ) > 0 ) {
+			update_site_option( static::SITE_OPTION, $auto_updates );
+		} else {
+			delete_site_option( static::SITE_OPTION );
+		}
+
+		Utils\report_batch_operation_results(
+			'plugin auto-update',
+			'disable',
+			$count,
+			$successes,
+			$count - $successes
+		);
+	}
+
+	/**
+	 * Shows the status of auto-updates for a plugin.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<plugin>...]
+	 * : One or more plugins to show the status of the auto-updates of.
+	 *
+	 * [--all]
+	 * : If set, the status of auto-updates for all plugins will be shown.
+	 *
+	 * [--enabled-only]
+	 * : If set, filters list of plugins to only include the ones that have
+	 * auto-updates enabled.
+	 *
+	 * [--disabled-only]
+	 * : If set, filters list of plugins to only include the ones that have
+	 * auto-updates disabled.
+	 *
+	 * [--field=<field>]
+	 * : Only show the provided field.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Get the status of plugin auto-updates
+	 *     $ wp plugin auto-updates status hello
+	 *     +-------+----------+
+	 *     | name  | status   |
+	 *     +-------+----------+
+	 *     | hello | disabled |
+	 *     +-------+----------+
+	 *
+	 *     # Get the list of plugins that have auto-updates enabled
+	 *     $ wp plugin auto-updates status --all --enabled-only --field=name
+	 *     akismet
+	 *     duplicate-post
+	 */
+	public function status( $args, $assoc_args ) {
+		$all           = Utils\get_flag_value( $assoc_args, 'all', false );
+		$enabled_only  = Utils\get_flag_value( $assoc_args, 'enabled-only', false );
+		$disabled_only = Utils\get_flag_value( $assoc_args, 'disabled-only', false );
+
+		if ( $enabled_only && $disabled_only ) {
+			WP_CLI::error(
+				'--enabled-only and --disabled-only are mutually exclusive and '
+				. 'cannot be used at the same time.'
+			);
+		}
+
+		$args = $this->check_optional_args_and_all( $args, $all );
+		if ( ! $args ) {
+			return;
+		}
+
+		$plugins      = $this->fetcher->get_many( $args );
+		$auto_updates = get_site_option( static::SITE_OPTION );
+
+		if ( false === $auto_updates ) {
+			$auto_updates = [];
+		}
+
+		$results = [];
+
+		foreach ( $plugins as $plugin ) {
+			$enabled = in_array( $plugin->file, $auto_updates, true );
+
+			if ( $enabled_only && ! $enabled ) {
+				continue;
+			}
+
+			if ( $disabled_only && $enabled ) {
+				continue;
+			}
+
+			$results[] = [
+				'name'   => $plugin->name,
+				'file'   => $plugin->file,
+				'status' => $enabled ? 'enabled' : 'disabled',
+			];
+		}
+
+		$formatter = new Formatter( $assoc_args, [ 'name', 'status' ], 'plugin' );
+		$formatter->display_items( $results );
+	}
+}

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1,5 +1,6 @@
 <?php
 
+use WP_CLI\ParsePluginNameInput;
 use WP_CLI\Utils;
 
 /**
@@ -40,6 +41,8 @@ use WP_CLI\Utils;
  */
 class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
+	use ParsePluginNameInput;
+
 	protected $item_type         = 'plugin';
 	protected $upgrade_refresh   = 'wp_update_plugins';
 	protected $upgrade_transient = 'update_plugins';
@@ -50,6 +53,13 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		'update',
 		'version',
 	);
+
+	/**
+	 * Plugin fetcher instance.
+	 *
+	 * @var \WP_CLI\Fetchers\Plugin
+	 */
+	protected $fetcher;
 
 	public function __construct() {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -1189,47 +1199,5 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		}
 
 		return ! WP_CLI::launch( $command . escapeshellarg( $path ) );
-	}
-
-	/**
-	 * Gets all available plugins.
-	 *
-	 * Uses the same filter core uses in plugins.php to determine which plugins
-	 * should be available to manage through the WP_Plugins_List_Table class.
-	 *
-	 * @return array
-	 */
-	private function get_all_plugins() {
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Calling native WordPress hook.
-		return apply_filters( 'all_plugins', get_plugins() );
-	}
-
-	/**
-	 * If have optional args ([<plugin>...]) and an all option, then check have something to do.
-	 *
-	 * @param array $args Passed-in arguments.
-	 * @param bool $all All flag.
-	 * @return array Same as $args if not all, otherwise all slugs.
-	 */
-	private function check_optional_args_and_all( $args, $all, $verb = 'install' ) {
-		if ( $all ) {
-			$args = array_map(
-				function( $file ) {
-						return Utils\get_plugin_name( $file );
-				},
-				array_keys( $this->get_all_plugins() )
-			);
-		}
-
-		if ( empty( $args ) ) {
-			if ( ! $all ) {
-				WP_CLI::error( 'Please specify one or more plugins, or use --all.' );
-			}
-
-			$past_tense_verb = Utils\past_tense_verb( $verb );
-			WP_CLI::success( "No plugins {$past_tense_verb}." ); // Don't error if --all given for BC.
-		}
-
-		return $args;
 	}
 }

--- a/src/Theme_AutoUpdates_Command.php
+++ b/src/Theme_AutoUpdates_Command.php
@@ -1,0 +1,291 @@
+<?php
+
+use WP_CLI\Fetchers\Theme;
+use WP_CLI\Formatter;
+use WP_CLI\ParseThemeNameInput;
+use WP_CLI\Utils;
+
+/**
+ * Manages theme auto-updates.
+ *
+ * ## EXAMPLES
+ *
+ *     # Enable the auto-updates for a theme
+ *     $ wp theme auto-updates enable activate twentysixteen
+ *     Theme auto-updates for 'twentysixteen' enabled.
+ *     Success: Enabled 1 of 1 theme auto-updates.
+ *
+ *     # Disable the auto-updates for a theme
+ *     $ wp theme auto-updates disable activate twentysixteen
+ *     Theme auto-updates for 'twentysixteen' disabled.
+ *     Success: Disabled 1 of 1 theme auto-updates.
+ *
+ *     # Get the status of theme auto-updates
+ *     $ wp theme auto-updates status twentysixteen
+ *     Auto-updates for theme 'twentysixteen' are disabled.
+ *
+ * @package wp-cli
+ */
+class Theme_AutoUpdates_Command {
+
+	use ParseThemeNameInput;
+
+	/**
+	 * Site option that stores the status of theme auto-updates.
+	 *
+	 * @var string
+	 */
+	const SITE_OPTION = 'auto_update_themes';
+
+	/**
+	 * Theme fetcher instance.
+	 *
+	 * @var Theme
+	 */
+	protected $fetcher;
+
+	/**
+	 * Theme_AutoUpdates_Command constructor.
+	 */
+	public function __construct() {
+		$this->fetcher = new Theme();
+	}
+
+	/**
+	 * Enables the auto-updates for a theme.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<theme>...]
+	 * : One or more themes to enable auto-updates for.
+	 *
+	 * [--all]
+	 * : If set, auto-updates will be enabled for all themes.
+	 *
+	 * [--disabled-only]
+	 * : If set, filters list of themes to only include the ones that have
+	 * auto-updates disabled.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Enable the auto-updates for a theme
+	 *     $ wp theme auto-updates enable activate twentysixteen
+	 *     Theme auto-updates for 'twentysixteen' enabled.
+	 *     Success: Enabled 1 of 1 theme auto-updates.
+	 */
+	public function enable( $args, $assoc_args ) {
+		$all           = Utils\get_flag_value( $assoc_args, 'all', false );
+		$disabled_only = Utils\get_flag_value( $assoc_args, 'disabled-only', false );
+
+		$args = $this->check_optional_args_and_all( $args, $all );
+
+		$themes       = $this->fetcher->get_many( $args );
+		$auto_updates = get_site_option( static::SITE_OPTION );
+
+		if ( false === $auto_updates ) {
+			$auto_updates = [];
+		}
+
+		$count     = 0;
+		$successes = 0;
+
+		foreach ( $themes as $theme ) {
+			$enabled = in_array( $theme->stylesheet, $auto_updates, true );
+
+			if ( $disabled_only && $enabled ) {
+				continue;
+			}
+
+			$count++;
+
+			if ( $enabled ) {
+				WP_CLI::warning(
+					"Auto-updates already enabled for theme {$theme->stylesheet}."
+				);
+			} else {
+				$auto_updates[] = $theme->stylesheet;
+				$successes++;
+			}
+		}
+
+		if ( 0 === $count ) {
+			WP_CLI::error(
+				'No themes provided to enable auto-updates for.'
+			);
+		}
+
+		update_site_option( static::SITE_OPTION, $auto_updates );
+
+		Utils\report_batch_operation_results(
+			'theme auto-update',
+			'enable',
+			$count,
+			$successes,
+			$count - $successes
+		);
+	}
+
+	/**
+	 * Disables the auto-updates for a theme.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<theme>...]
+	 * : One or more themes to disable auto-updates for.
+	 *
+	 * [--all]
+	 * : If set, auto-updates will be disabled for all themes.
+	 *
+	 * [--enabled-only]
+	 * : If set, filters list of themes to only include the ones that have
+	 * auto-updates enabled.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Disable the auto-updates for a theme
+	 *     $ wp theme auto-updates disable activate twentysixteen
+	 *     Theme auto-updates for 'twentysixteen' disabled.
+	 *     Success: Disabled 1 of 1 theme auto-updates.
+	 */
+	public function disable( $args, $assoc_args ) {
+		$all          = Utils\get_flag_value( $assoc_args, 'all', false );
+		$enabled_only = Utils\get_flag_value( $assoc_args, 'enabled-only', false );
+
+		$args = $this->check_optional_args_and_all( $args, $all );
+
+		$themes       = $this->fetcher->get_many( $args );
+		$auto_updates = get_site_option( static::SITE_OPTION );
+
+		if ( false === $auto_updates ) {
+			$auto_updates = [];
+		}
+
+		$count     = 0;
+		$successes = 0;
+
+		foreach ( $themes as $theme ) {
+			$enabled = in_array( $theme->stylesheet, $auto_updates, true );
+
+			if ( $enabled_only && ! $enabled ) {
+				continue;
+			}
+
+			$count++;
+
+			if ( ! $enabled ) {
+				WP_CLI::warning(
+					"Auto-updates already disabled for theme {$theme->stylesheet}."
+				);
+			} else {
+				$auto_updates = array_diff( $auto_updates, [ $theme->stylesheet ] );
+				$successes++;
+			}
+		}
+
+		if ( 0 === $count ) {
+			WP_CLI::error(
+				'No themes provided to disable auto-updates for.'
+			);
+		}
+
+		if ( count( $auto_updates ) > 0 ) {
+			update_site_option( static::SITE_OPTION, $auto_updates );
+		} else {
+			delete_site_option( static::SITE_OPTION );
+		}
+
+		Utils\report_batch_operation_results(
+			'theme auto-update',
+			'disable',
+			$count,
+			$successes,
+			$count - $successes
+		);
+	}
+
+	/**
+	 * Shows the status of auto-updates for a theme.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<theme>...]
+	 * : One or more themes to show the status of the auto-updates of.
+	 *
+	 * [--all]
+	 * : If set, the status of auto-updates for all themes will be shown.
+	 *
+	 * [--enabled-only]
+	 * : If set, filters list of themes to only include the ones that have
+	 * auto-updates enabled.
+	 *
+	 * [--disabled-only]
+	 * : If set, filters list of themes to only include the ones that have
+	 * auto-updates disabled.
+	 *
+	 * [--field=<field>]
+	 * : Only show the provided field.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Get the status of theme auto-updates
+	 *     $ wp theme auto-updates status twentysixteen
+	 *     +---------------+----------+
+	 *     | name          | status   |
+	 *     +---------------+----------+
+	 *     | twentysixteen | disabled |
+	 *     +---------------+----------+
+	 *
+	 *     # Get the list of themes that have auto-updates enabled
+	 *     $ wp theme auto-updates status --all --enabled-only --field=name
+	 *     akismet
+	 *     duplicate-post
+	 */
+	public function status( $args, $assoc_args ) {
+		$all           = Utils\get_flag_value( $assoc_args, 'all', false );
+		$enabled_only  = Utils\get_flag_value( $assoc_args, 'enabled-only', false );
+		$disabled_only = Utils\get_flag_value( $assoc_args, 'disabled-only', false );
+
+		if ( $enabled_only && $disabled_only ) {
+			WP_CLI::error(
+				'--enabled-only and --disabled-only are mutually exclusive and '
+				. 'cannot be used at the same time.'
+			);
+		}
+
+		$args = $this->check_optional_args_and_all( $args, $all );
+		if ( ! $args ) {
+			return;
+		}
+
+		$themes       = $this->fetcher->get_many( $args );
+		$auto_updates = get_site_option( static::SITE_OPTION );
+
+		if ( false === $auto_updates ) {
+			$auto_updates = [];
+		}
+
+		$results = [];
+
+		foreach ( $themes as $theme ) {
+			$enabled = in_array( $theme->stylesheet, $auto_updates, true );
+
+			if ( $enabled_only && ! $enabled ) {
+				continue;
+			}
+
+			if ( $disabled_only && $enabled ) {
+				continue;
+			}
+
+			$results[] = [
+				'name'   => $theme->stylesheet,
+				'name
+			'            => $theme->stylesheet,
+				'status' => $enabled ? 'enabled' : 'disabled',
+			];
+		}
+
+		$formatter = new Formatter( $assoc_args, [ 'name', 'status' ], 'theme' );
+		$formatter->display_items( $results );
+	}
+}

--- a/src/Theme_AutoUpdates_Command.php
+++ b/src/Theme_AutoUpdates_Command.php
@@ -237,8 +237,8 @@ class Theme_AutoUpdates_Command {
 	 *
 	 *     # Get the list of themes that have auto-updates enabled
 	 *     $ wp theme auto-updates status --all --enabled-only --field=name
-	 *     akismet
-	 *     duplicate-post
+	 *     twentysixteen
+	 *     twentyseventeen
 	 */
 	public function status( $args, $assoc_args ) {
 		$all           = Utils\get_flag_value( $assoc_args, 'all', false );

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -858,33 +858,6 @@ class Theme_Command extends CommandWithUpgrade {
 	}
 
 	/**
-	 * If have optional args ([<theme>...]) and an all option, then check have something to do.
-	 *
-	 * @param array $args Passed-in arguments.
-	 * @param bool $all All flag.
-	 * @return array Same as $args if not all, otherwise all slugs.
-	 */
-	private function check_optional_args_and_all( $args, $all, $verb = 'install' ) {
-		if ( $all ) {
-			$args = array_map(
-				function( $item ) {
-						return Utils\get_theme_name( $item );
-				},
-				array_keys( $this->get_all_items() )
-			);
-		}
-
-		if ( empty( $args ) ) {
-			if ( ! $all ) {
-				WP_CLI::error( 'Please specify one or more themes, or use --all.' );
-			}
-			WP_CLI::success( 'No themes installed.' ); // Don't error if --all given for BC.
-		}
-
-		return $args;
-	}
-
-	/**
 	 * Gets the template path based on installation type.
 	 */
 	private static function get_template_path( $template ) {

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -16,6 +16,9 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 	protected $chained_command = false;
 
+	// Invalid version message.
+	const INVALID_VERSION_MESSAGE = 'version higher than expected';
+
 	public function __construct() {
 
 		// Do not automatically check translations updates after updating plugins/themes.

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -16,9 +16,6 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 	protected $chained_command = false;
 
-	// Invalid version message.
-	const INVALID_VERSION_MESSAGE = 'version higher than expected';
-
 	public function __construct() {
 
 		// Do not automatically check translations updates after updating plugins/themes.

--- a/src/WP_CLI/ParsePluginNameInput.php
+++ b/src/WP_CLI/ParsePluginNameInput.php
@@ -9,9 +9,11 @@ trait ParsePluginNameInput {
 	/**
 	 * If have optional args ([<plugin>...]) and an all option, then check have something to do.
 	 *
-	 * @param array $args Passed-in arguments.
-	 * @param bool $all All flag.
+	 * @param array  $args Passed-in arguments.
+	 * @param bool   $all All flag.
+	 * @param string $verb Optional. Verb to use. Defaults to 'install'.
 	 * @return array Same as $args if not all, otherwise all slugs.
+	 * @throws ExitException If neither plugin name nor --all were provided.
 	 */
 	protected function check_optional_args_and_all( $args, $all, $verb = 'install' ) {
 		if ( $all ) {

--- a/src/WP_CLI/ParsePluginNameInput.php
+++ b/src/WP_CLI/ParsePluginNameInput.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace WP_CLI;
+
+use WP_CLI;
+
+trait ParsePluginNameInput {
+
+	/**
+	 * If have optional args ([<plugin>...]) and an all option, then check have something to do.
+	 *
+	 * @param array $args Passed-in arguments.
+	 * @param bool $all All flag.
+	 * @return array Same as $args if not all, otherwise all slugs.
+	 */
+	protected function check_optional_args_and_all( $args, $all, $verb = 'install' ) {
+		if ( $all ) {
+			$args = array_map(
+				'\WP_CLI\Utils\get_plugin_name',
+				array_keys( $this->get_all_plugins() )
+			);
+		}
+
+		if ( empty( $args ) ) {
+			if ( ! $all ) {
+				WP_CLI::error( 'Please specify one or more plugins, or use --all.' );
+			}
+
+			$past_tense_verb = Utils\past_tense_verb( $verb );
+			WP_CLI::success( "No plugins {$past_tense_verb}." ); // Don't error if --all given for BC.
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Gets all available plugins.
+	 *
+	 * Uses the same filter core uses in plugins.php to determine which plugins
+	 * should be available to manage through the WP_Plugins_List_Table class.
+	 *
+	 * @return array
+	 */
+	private function get_all_plugins() {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Calling native WordPress hook.
+		return apply_filters( 'all_plugins', get_plugins() );
+	}
+}

--- a/src/WP_CLI/ParseThemeNameInput.php
+++ b/src/WP_CLI/ParseThemeNameInput.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace WP_CLI;
+
+use WP_CLI;
+
+trait ParseThemeNameInput {
+
+	/**
+	 * If have optional args ([<theme>...]) and an all option, then check have something to do.
+	 *
+	 * @param array  $args Passed-in arguments.
+	 * @param bool   $all All flag.
+	 * @param string $verb Optional. Verb to use. Defaults to 'install'.
+	 * @return array Same as $args if not all, otherwise all slugs.
+	 * @throws ExitException If neither plugin name nor --all were provided.
+	 */
+	protected function check_optional_args_and_all( $args, $all, $verb = 'install' ) {
+		if ( $all ) {
+			$args = array_map(
+				'\WP_CLI\Utils\get_theme_name',
+				array_keys( $this->get_all_themes() )
+			);
+		}
+
+		if ( empty( $args ) ) {
+			if ( ! $all ) {
+				WP_CLI::error( 'Please specify one or more themes, or use --all.' );
+			}
+
+			$past_tense_verb = Utils\past_tense_verb( $verb );
+			WP_CLI::success( "No themes {$past_tense_verb}." ); // Don't error if --all given for BC.
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Gets all available themes.
+	 *
+	 * Uses the same filter core uses in themes.php to determine which themes
+	 * should be available to manage through the WP_Themes_List_Table class.
+	 *
+	 * @return array
+	 */
+	private function get_all_themes() {
+		$items              = array();
+		$theme_version_info = array();
+
+		if ( is_multisite() ) {
+			$site_enabled = get_option( 'allowedthemes' );
+			if ( empty( $site_enabled ) ) {
+				$site_enabled = array();
+			}
+
+			$network_enabled = get_site_option( 'allowedthemes' );
+			if ( empty( $network_enabled ) ) {
+				$network_enabled = array();
+			}
+		}
+
+		$all_update_info = $this->get_update_info();
+		$checked_themes  = isset( $all_update_info->checked ) ? $all_update_info->checked : array();
+
+		if ( ! empty( $checked_themes ) ) {
+			foreach ( $checked_themes as $slug => $version ) {
+				$theme_version_info[ $slug ] = $this->is_theme_version_valid( $slug, $version );
+			}
+		}
+
+		foreach ( wp_get_themes() as $key => $theme ) {
+			$file = $theme->get_stylesheet_directory();
+
+			$update_info = ( isset( $all_update_info->response[ $theme->get_stylesheet() ] ) && null !== $all_update_info->response[ $theme->get_stylesheet() ] ) ? (array) $all_update_info->response[ $theme->get_stylesheet() ] : null;
+
+			$items[ $file ] = [
+				'name'           => $key,
+				'status'         => $this->get_status( $theme ),
+				'update'         => (bool) $update_info,
+				'update_version' => isset( $update_info['new_version'] ) ? $update_info['new_version'] : null,
+				'update_package' => isset( $update_info['package'] ) ? $update_info['package'] : null,
+				'version'        => $theme->get( 'Version' ),
+				'update_id'      => $theme->get_stylesheet(),
+				'title'          => $theme->get( 'Name' ),
+				'description'    => wordwrap( $theme->get( 'Description' ) ),
+				'author'         => $theme->get( 'Author' ),
+			];
+
+			// Compare version and update information in theme list.
+			if ( isset( $theme_version_info[ $key ] ) && false === $theme_version_info[ $key ] ) {
+				$items[ $file ]['update'] = 'version higher than expected';
+			}
+
+			if ( is_multisite() ) {
+				if ( ! empty( $site_enabled[ $key ] ) && ! empty( $network_enabled[ $key ] ) ) {
+					$items[ $file ]['enabled'] = 'network,site';
+				} elseif ( ! empty( $network_enabled[ $key ] ) ) {
+					$items[ $file ]['enabled'] = 'network';
+				} elseif ( ! empty( $site_enabled[ $key ] ) ) {
+					$items[ $file ]['enabled'] = 'site';
+				} else {
+					$items[ $file ]['enabled'] = 'no';
+				}
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Check if current version of the theme is higher than the one available at WP.org.
+	 *
+	 * @param string $slug Theme slug.
+	 * @param string $version Theme current version.
+	 *
+	 * @return bool|string
+	 */
+	protected function is_theme_version_valid( $slug, $version ) {
+		// Get Theme Info.
+		$theme_info = themes_api( 'theme_information', array( 'slug' => $slug ) );
+
+		// Return empty string for themes not on WP.org.
+		if ( is_wp_error( $theme_info ) ) {
+			return '';
+		}
+
+		// Compare theme version info.
+		return ! version_compare( $version, $theme_info->version, '>' );
+	}
+
+	/**
+	 * Get the status for a given theme.
+	 *
+	 * @param string $theme Theme to get the status for.
+	 *
+	 * @return string Status of the theme.
+	 */
+	protected function get_status( $theme ) {
+		if ( $this->is_active_theme( $theme ) ) {
+			return 'active';
+		}
+
+		if ( $theme->get_stylesheet_directory() === get_template_directory() ) {
+			return 'parent';
+		}
+
+		return 'inactive';
+	}
+
+	/**
+	 * Check whether a given theme is the active theme.
+	 *
+	 * @param string $theme Theme to check.
+	 *
+	 * @return bool Whether the provided theme is the active theme.
+	 */
+	protected function is_active_theme( $theme ) {
+		return $theme->get_stylesheet_directory() === get_stylesheet_directory();
+	}
+
+	/**
+	 * Get the available update info.
+	 *
+	 * @return mixed Available update info.
+	 */
+	protected function get_update_info() {
+		return get_site_transient( 'update_themes' );
+	}
+}


### PR DESCRIPTION
This PR adds the following commands:

`wp plugin auto-updates status [<plugin>...] [--all] [--enabled-only] [--disabled-only]
  [--field=<field>]`
`wp plugin auto-updates enable [<plugin>...] [--all] [--disabled-only]`
`wp plugin auto-updates disable [<plugin>...] [--all] [--enabled-only]`
`wp theme auto-updates status [<theme>...] [--all] [--enabled-only] [--disabled-only]
  [--field=<field>]`
`wp theme auto-updates enable [<theme>...] [--all] [--disabled-only]`
`wp theme auto-updates disable [<theme>...] [--all] [--enabled-only]`

Fixes #259 