### PR TITLE
Only run `auto-updates` commands on WP 5.5+

### DIFF
--- a/extension-command.php
+++ b/extension-command.php
@@ -9,8 +9,16 @@ if ( file_exists( $wpcli_extension_autoloader ) ) {
 	require_once $wpcli_extension_autoloader;
 }
 
+$wpcli_extension_requires_wp_5_5 = [
+	'before_invoke' => static function () {
+		if ( WP_CLI\Utils\wp_version_compare( '5.5', '<' ) ) {
+			WP_CLI::error( 'Requires WordPress 5.5 or greater.' );
+		}
+	},
+];
+
 WP_CLI::add_command( 'plugin', 'Plugin_Command' );
-WP_CLI::add_command( 'plugin auto-updates', 'Plugin_AutoUpdates_Command' );
+WP_CLI::add_command( 'plugin auto-updates', 'Plugin_AutoUpdates_Command', $wpcli_extension_requires_wp_5_5 );
 WP_CLI::add_command( 'theme', 'Theme_Command' );
-WP_CLI::add_command( 'theme auto-updates', 'Theme_AutoUpdates_Command' );
+WP_CLI::add_command( 'theme auto-updates', 'Theme_AutoUpdates_Command', $wpcli_extension_requires_wp_5_5 );
 WP_CLI::add_command( 'theme mod', 'Theme_Mod_Command' );

--- a/features/plugin-auto-updates-disable.feature
+++ b/features/plugin-auto-updates-disable.feature
@@ -5,6 +5,7 @@ Feature: Disable auto-updates for WordPress plugins
     And I run `wp plugin install duplicate-post`
     And I run `wp plugin auto-updates enable --all`
 
+  @require-wp-5.5
   Scenario: Show an error if required params are missing
     When I try `wp plugin auto-updates disable`
     Then STDOUT should be empty
@@ -13,6 +14,7 @@ Feature: Disable auto-updates for WordPress plugins
       Error: Please specify one or more plugins, or use --all.
       """
 
+  @require-wp-5.5
   Scenario: Disable auto-updates for a single plugin
     When I run `wp plugin auto-updates disable hello`
     Then STDOUT should be:
@@ -21,6 +23,7 @@ Feature: Disable auto-updates for WordPress plugins
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Disable auto-updates for multiple plugins
     When I run `wp plugin auto-updates disable hello duplicate-post`
     Then STDOUT should be:
@@ -29,6 +32,7 @@ Feature: Disable auto-updates for WordPress plugins
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Disable auto-updates for all plugins
     When I run `wp plugin auto-updates disable --all`
     Then STDOUT should be:
@@ -37,6 +41,7 @@ Feature: Disable auto-updates for WordPress plugins
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Disable auto-updates for already disabled plugins
     When I run `wp plugin auto-updates disable hello`
     And I try `wp plugin auto-updates disable --all`
@@ -49,6 +54,7 @@ Feature: Disable auto-updates for WordPress plugins
       Error: Only disabled 2 of 3 plugin auto-updates.
       """
 
+  @require-wp-5.5
   Scenario: Filter when enabling auto-updates for already disabled plugins
     When I run `wp plugin auto-updates disable hello`
     And I run `wp plugin auto-updates disable --all --enabled-only`
@@ -58,6 +64,7 @@ Feature: Disable auto-updates for WordPress plugins
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Filter when enabling auto-updates for already disabled selection of plugins
     When I run `wp plugin auto-updates disable hello`
     And I run `wp plugin auto-updates disable hello duplicate-post --enabled-only`
@@ -67,6 +74,7 @@ Feature: Disable auto-updates for WordPress plugins
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Filtering everything away produces an error
     When I run `wp plugin auto-updates disable hello`
     And I try `wp plugin auto-updates disable hello --enabled-only`

--- a/features/plugin-auto-updates-enable.feature
+++ b/features/plugin-auto-updates-enable.feature
@@ -4,6 +4,7 @@ Feature: Enable auto-updates for WordPress plugins
     Given a WP install
     And I run `wp plugin install duplicate-post`
 
+  @require-wp-5.5
   Scenario: Show an error if required params are missing
     When I try `wp plugin auto-updates enable`
     Then STDOUT should be empty
@@ -12,6 +13,7 @@ Feature: Enable auto-updates for WordPress plugins
       Error: Please specify one or more plugins, or use --all.
       """
 
+  @require-wp-5.5
   Scenario: Enable auto-updates for a single plugin
     When I run `wp plugin auto-updates enable hello`
     Then STDOUT should be:
@@ -20,6 +22,7 @@ Feature: Enable auto-updates for WordPress plugins
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Enable auto-updates for multiple plugins
     When I run `wp plugin auto-updates enable hello duplicate-post`
     Then STDOUT should be:
@@ -28,6 +31,7 @@ Feature: Enable auto-updates for WordPress plugins
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Enable auto-updates for all plugins
     When I run `wp plugin auto-updates enable --all`
     Then STDOUT should be:
@@ -36,6 +40,7 @@ Feature: Enable auto-updates for WordPress plugins
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Enable auto-updates for already enabled plugins
     When I run `wp plugin auto-updates enable hello`
     And I try `wp plugin auto-updates enable --all`
@@ -48,6 +53,7 @@ Feature: Enable auto-updates for WordPress plugins
       Error: Only enabled 2 of 3 plugin auto-updates.
       """
 
+  @require-wp-5.5
   Scenario: Filter when enabling auto-updates for already enabled plugins
     When I run `wp plugin auto-updates enable hello`
     And I run `wp plugin auto-updates enable --all --disabled-only`
@@ -57,6 +63,7 @@ Feature: Enable auto-updates for WordPress plugins
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Filter when enabling auto-updates for already enabled selection of plugins
     When I run `wp plugin auto-updates enable hello`
     And I run `wp plugin auto-updates enable hello duplicate-post --disabled-only`
@@ -66,6 +73,7 @@ Feature: Enable auto-updates for WordPress plugins
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Filtering everything away produces an error
     When I run `wp plugin auto-updates enable hello`
     And I try `wp plugin auto-updates enable hello --disabled-only`

--- a/features/plugin-auto-updates-status.feature
+++ b/features/plugin-auto-updates-status.feature
@@ -4,6 +4,7 @@ Feature: Show the status of auto-updates for WordPress plugins
     Given a WP install
     And I run `wp plugin install duplicate-post`
 
+  @require-wp-5.5
   Scenario: Show an error if required params are missing
     When I try `wp plugin auto-updates status`
     Then STDOUT should be empty
@@ -12,6 +13,7 @@ Feature: Show the status of auto-updates for WordPress plugins
       Error: Please specify one or more plugins, or use --all.
       """
 
+  @require-wp-5.5
   Scenario: Show the status of auto-updates of a single plugin
     When I run `wp plugin auto-updates status hello`
     Then STDOUT should be a table containing rows:
@@ -19,6 +21,7 @@ Feature: Show the status of auto-updates for WordPress plugins
       | hello          | disabled |
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Show the status of auto-updates multiple plugins
     When I run `wp plugin auto-updates status duplicate-post hello`
     Then STDOUT should be a table containing rows:
@@ -27,6 +30,7 @@ Feature: Show the status of auto-updates for WordPress plugins
       | hello          | disabled |
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Show the status of auto-updates all installed plugins
     When I run `wp plugin auto-updates status --all`
     Then STDOUT should be a table containing rows:
@@ -45,6 +49,7 @@ Feature: Show the status of auto-updates for WordPress plugins
       | hello          | enabled  |
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: The status can be filtered to only show enabled or disabled plugins
     Given I run `wp plugin auto-updates enable hello`
 
@@ -76,6 +81,7 @@ Feature: Show the status of auto-updates for WordPress plugins
       Error: --enabled-only and --disabled-only are mutually exclusive and cannot be used at the same time.
       """
 
+  @require-wp-5.5
   Scenario: The fields can be shown individually
     Given I run `wp plugin auto-updates enable hello`
 

--- a/features/theme-auto-update-status.feature
+++ b/features/theme-auto-update-status.feature
@@ -7,6 +7,7 @@ Feature: Show the status of auto-updates for WordPress themes
     And I run `wp theme install twentyseventeen`
     And I run `wp theme install twentynineteen`
 
+  @require-wp-5.5
   Scenario: Show an error if required params are missing
     When I try `wp theme auto-updates status`
     Then STDOUT should be empty
@@ -15,6 +16,7 @@ Feature: Show the status of auto-updates for WordPress themes
       Error: Please specify one or more themes, or use --all.
       """
 
+  @require-wp-5.5
   Scenario: Show the status of auto-updates of a single theme
     When I run `wp theme auto-updates status twentysixteen`
     Then STDOUT should be a table containing rows:
@@ -22,6 +24,7 @@ Feature: Show the status of auto-updates for WordPress themes
       | twentysixteen   | disabled |
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Show the status of auto-updates multiple themes
     When I run `wp theme auto-updates status twentyseventeen twentysixteen`
     Then STDOUT should be a table containing rows:
@@ -30,6 +33,7 @@ Feature: Show the status of auto-updates for WordPress themes
       | twentysixteen   | disabled |
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Show the status of auto-updates all installed themes
     When I run `wp theme auto-updates status --all`
     Then STDOUT should be a table containing rows:
@@ -48,6 +52,7 @@ Feature: Show the status of auto-updates for WordPress themes
       | twentysixteen   | enabled  |
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: The status can be filtered to only show enabled or disabled themes
     Given I run `wp theme auto-updates enable twentysixteen`
 
@@ -79,6 +84,7 @@ Feature: Show the status of auto-updates for WordPress themes
       Error: --enabled-only and --disabled-only are mutually exclusive and cannot be used at the same time.
       """
 
+  @require-wp-5.5
   Scenario: The fields can be shown individually
     Given I run `wp theme auto-updates enable twentysixteen`
 

--- a/features/theme-auto-updates-disable.feature
+++ b/features/theme-auto-updates-disable.feature
@@ -8,6 +8,7 @@ Feature: Disable auto-updates for WordPress themes
     And I run `wp theme install twentynineteen`
     And I try `wp theme auto-updates enable --all`
 
+  @require-wp-5.5
   Scenario: Show an error if required params are missing
     When I try `wp theme auto-updates disable`
     Then STDOUT should be empty
@@ -16,6 +17,7 @@ Feature: Disable auto-updates for WordPress themes
       Error: Please specify one or more themes, or use --all.
       """
 
+  @require-wp-5.5
   Scenario: Disable auto-updates for a single theme
     When I run `wp theme auto-updates disable twentysixteen`
     Then STDOUT should be:
@@ -24,6 +26,7 @@ Feature: Disable auto-updates for WordPress themes
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Disable auto-updates for multiple themes
     When I run `wp theme auto-updates disable twentysixteen twentyseventeen`
     Then STDOUT should be:
@@ -32,6 +35,7 @@ Feature: Disable auto-updates for WordPress themes
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Disable auto-updates for all themes
     When I run `wp theme auto-updates disable --all`
     Then STDOUT should be:
@@ -40,6 +44,7 @@ Feature: Disable auto-updates for WordPress themes
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Disable auto-updates for already disabled themes
     When I run `wp theme auto-updates disable twentysixteen`
     And I try `wp theme auto-updates disable --all`
@@ -52,6 +57,7 @@ Feature: Disable auto-updates for WordPress themes
       Error: Only disabled 2 of 3 theme auto-updates.
       """
 
+  @require-wp-5.5
   Scenario: Filter when enabling auto-updates for already disabled themes
     When I run `wp theme auto-updates disable twentysixteen`
     And I run `wp theme auto-updates disable --all --enabled-only`
@@ -61,6 +67,7 @@ Feature: Disable auto-updates for WordPress themes
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Filter when enabling auto-updates for already disabled selection of themes
     When I run `wp theme auto-updates disable twentysixteen`
     And I run `wp theme auto-updates disable twentysixteen twentyseventeen --enabled-only`
@@ -70,6 +77,7 @@ Feature: Disable auto-updates for WordPress themes
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Filtering everything away produces an error
     When I run `wp theme auto-updates disable twentysixteen`
     And I try `wp theme auto-updates disable twentysixteen --enabled-only`

--- a/features/theme-auto-updates-enable.feature
+++ b/features/theme-auto-updates-enable.feature
@@ -8,6 +8,7 @@ Feature: Enable auto-updates for WordPress themes
     And I run `wp theme install twentynineteen`
     And I try `wp theme auto-updates disable --all`
 
+  @require-wp-5.5
   Scenario: Show an error if required params are missing
     When I try `wp theme auto-updates enable`
     Then STDOUT should be empty
@@ -16,6 +17,7 @@ Feature: Enable auto-updates for WordPress themes
       Error: Please specify one or more themes, or use --all.
       """
 
+  @require-wp-5.5
   Scenario: Enable auto-updates for a single theme
     When I run `wp theme auto-updates enable twentysixteen`
     Then STDOUT should be:
@@ -24,6 +26,7 @@ Feature: Enable auto-updates for WordPress themes
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Enable auto-updates for multiple themes
     When I run `wp theme auto-updates enable twentysixteen twentyseventeen`
     Then STDOUT should be:
@@ -32,6 +35,7 @@ Feature: Enable auto-updates for WordPress themes
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Enable auto-updates for all themes
     When I run `wp theme auto-updates enable --all`
     Then STDOUT should be:
@@ -40,6 +44,7 @@ Feature: Enable auto-updates for WordPress themes
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Enable auto-updates for already enabled themes
     When I run `wp theme auto-updates enable twentysixteen`
     And I try `wp theme auto-updates enable --all`
@@ -52,6 +57,7 @@ Feature: Enable auto-updates for WordPress themes
       Error: Only enabled 2 of 3 theme auto-updates.
       """
 
+  @require-wp-5.5
   Scenario: Filter when enabling auto-updates for already enabled themes
     When I run `wp theme auto-updates enable twentysixteen`
     And I run `wp theme auto-updates enable --all --disabled-only`
@@ -61,6 +67,7 @@ Feature: Enable auto-updates for WordPress themes
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Filter when enabling auto-updates for already enabled selection of themes
     When I run `wp theme auto-updates enable twentysixteen`
     And I run `wp theme auto-updates enable twentysixteen twentyseventeen --disabled-only`
@@ -70,6 +77,7 @@ Feature: Enable auto-updates for WordPress themes
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Filtering everything away produces an error
     When I run `wp theme auto-updates enable twentysixteen`
     And I try `wp theme auto-updates enable twentysixteen --disabled-only`


### PR DESCRIPTION
Fixes #260 