### PR TITLE
Add `--insecure` flag to `plugin|theme install` & `plugin\theme update` commands

### DIFF
--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -593,6 +593,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * [--dry-run]
 	 * : Preview which plugins would be updated.
 	 *
+	 * [--insecure]
+	 * : Retry downloads without certificate validation if TLS handshake fails. Note: This makes the request vulnerable to a MITM attack.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp plugin update bbpress --version=dev
@@ -736,6 +739,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *
 	 * [--activate-network]
 	 * : If set, the plugin will be network activated immediately after install
+	 *
+	 * [--insecure]
+	 * : Retry downloads without certificate validation if TLS handshake fails. Note: This makes the request vulnerable to a MITM attack.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -457,6 +457,9 @@ class Theme_Command extends CommandWithUpgrade {
 	 * [--activate]
 	 * : If set, the theme will be activated immediately after install.
 	 *
+	 * [--insecure]
+	 * : Retry downloads without certificate validation if TLS handshake fails. Note: This makes the request vulnerable to a MITM attack.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Install the latest version from wordpress.org and activate
@@ -595,6 +598,9 @@ class Theme_Command extends CommandWithUpgrade {
 	 *
 	 * [--dry-run]
 	 * : Preview which themes would be updated.
+	 *
+	 * [--insecure]
+	 * : Retry downloads without certificate validation if TLS handshake fails. Note: This makes the request vulnerable to a MITM attack.
 	 *
 	 * ## EXAMPLES
 	 *


### PR DESCRIPTION
The PR https://github.com/wp-cli/wp-cli/pull/5523 changes the default behavior for `Utils\http_request()` so that it does not automatically retry a remote request that failed its TLS handshake by skipping certificate validation.

This PR adds the `--insecure` flag to the following commands to explicitly switch back to the previous behavior:

- `plugin install`
- `plugin update`
- `theme install`
- `theme update`