### PR TITLE
Fix incorrect examples

### DIFF
--- a/src/Plugin_AutoUpdates_Command.php
+++ b/src/Plugin_AutoUpdates_Command.php
@@ -11,12 +11,12 @@ use WP_CLI\Utils;
  * ## EXAMPLES
  *
  *     # Enable the auto-updates for a plugin
- *     $ wp plugin auto-updates enable activate hello
+ *     $ wp plugin auto-updates enable hello
  *     Plugin auto-updates for 'hello' enabled.
  *     Success: Enabled 1 of 1 plugin auto-updates.
  *
  *     # Disable the auto-updates for a plugin
- *     $ wp plugin auto-updates disable activate hello
+ *     $ wp plugin auto-updates disable hello
  *     Plugin auto-updates for 'hello' disabled.
  *     Success: Disabled 1 of 1 plugin auto-updates.
  *
@@ -69,7 +69,7 @@ class Plugin_AutoUpdates_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Enable the auto-updates for a plugin
-	 *     $ wp plugin auto-updates enable activate hello
+	 *     $ wp plugin auto-updates enable hello
 	 *     Plugin auto-updates for 'hello' enabled.
 	 *     Success: Enabled 1 of 1 plugin auto-updates.
 	 */
@@ -146,7 +146,7 @@ class Plugin_AutoUpdates_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Disable the auto-updates for a plugin
-	 *     $ wp plugin auto-updates disable activate hello
+	 *     $ wp plugin auto-updates disable hello
 	 *     Plugin auto-updates for 'hello' disabled.
 	 *     Success: Disabled 1 of 1 plugin auto-updates.
 	 */

--- a/src/Theme_AutoUpdates_Command.php
+++ b/src/Theme_AutoUpdates_Command.php
@@ -11,12 +11,12 @@ use WP_CLI\Utils;
  * ## EXAMPLES
  *
  *     # Enable the auto-updates for a theme
- *     $ wp theme auto-updates enable activate twentysixteen
+ *     $ wp theme auto-updates enable twentysixteen
  *     Theme auto-updates for 'twentysixteen' enabled.
  *     Success: Enabled 1 of 1 theme auto-updates.
  *
  *     # Disable the auto-updates for a theme
- *     $ wp theme auto-updates disable activate twentysixteen
+ *     $ wp theme auto-updates disable twentysixteen
  *     Theme auto-updates for 'twentysixteen' disabled.
  *     Success: Disabled 1 of 1 theme auto-updates.
  *
@@ -69,7 +69,7 @@ class Theme_AutoUpdates_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Enable the auto-updates for a theme
-	 *     $ wp theme auto-updates enable activate twentysixteen
+	 *     $ wp theme auto-updates enable twentysixteen
 	 *     Theme auto-updates for 'twentysixteen' enabled.
 	 *     Success: Enabled 1 of 1 theme auto-updates.
 	 */
@@ -146,7 +146,7 @@ class Theme_AutoUpdates_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Disable the auto-updates for a theme
-	 *     $ wp theme auto-updates disable activate twentysixteen
+	 *     $ wp theme auto-updates disable twentysixteen
 	 *     Theme auto-updates for 'twentysixteen' disabled.
 	 *     Success: Disabled 1 of 1 theme auto-updates.
 	 */


### PR DESCRIPTION
In the examples, somehow `activate` shows up after the command `wp auto-updates enable` and the command thinks `activate` is a plugin or theme on which to enable auto-updates. This seems like a mistake since there is an actual plugin/theme after `activate`.

I could be missing something, but the command didn't seem to work when I tried it as shown in the example.