### PR TITLE
Replace one-time-login with a sample plugin in the tests

### DIFF
--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -58,7 +58,7 @@ Feature: Install WordPress plugins
   Scenario: Don't attempt to rename ZIPs uploaded to GitHub's releases page
     Given a WP install
 
-    When I run `wp plugin install https://github.com/wp-cli-test/generic-example-plugin/archive/refs/tags/v0.1.0.zip`
+    When I run `wp plugin install https://github.com/wp-cli-test/generic-example-plugin/releases/download/v0.1.0/generic-example-plugin.0.1.0.zip`
     Then STDOUT should contain:
       """
       Plugin installed successfully.


### PR DESCRIPTION
Fixes #301

Replaces the plugin [one-time-login](https://github.com/danielbachhuber/one-time-login/) with a [sample WordPress plugin](https://github.com/Nikschavan/test-wordpress-plugin)