### PR TITLE
Fix: prevent parent theme removal on child theme delete --all

### DIFF
--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -771,10 +771,25 @@ class Theme_Command extends CommandWithUpgrade {
 
 		$successes = 0;
 		$errors    = 0;
+
+		$protected_from_delete = array();
+
 		foreach ( $this->fetcher->get_many( $args ) as $theme ) {
 			$theme_slug = $theme->get_stylesheet();
 
 			if ( $this->is_active_theme( $theme ) && ! $force ) {
+				$protected_from_delete[] = $theme_slug;
+
+				if ( wp_get_theme( $theme_slug )->parent() ) {
+					$protected_from_delete[] = wp_get_theme( $theme_slug )->parent()->get_stylesheet();
+				}
+			}
+		}
+
+		foreach ( $this->fetcher->get_many( $args ) as $theme ) {
+			$theme_slug = $theme->get_stylesheet();
+
+			if ( in_array( $theme_slug, $protected_from_delete ) ) {
 				if ( ! $all ) {
 					WP_CLI::warning( "Can't delete the currently active theme: $theme_slug" );
 					$errors++;
@@ -782,7 +797,7 @@ class Theme_Command extends CommandWithUpgrade {
 				continue;
 			}
 
-			$r = delete_theme( $theme_slug );
+			//$r = delete_theme( $theme_slug );
 
 			if ( is_wp_error( $r ) ) {
 				WP_CLI::warning( $r );


### PR DESCRIPTION
This PR will try and add a fix for the issue mentioned here https://github.com/wp-cli/wp-cli/issues/5570

Basically, it will first loop through the list of fetched themes and check if the actual active theme has a parent theme(is child theme) and if so, it will prevent the parent theme from being deleted unintentionally, this. unless `--force` is supplied.

The case when the user specifically deletes the parent theme folder with `wp theme delete parent-theme` is omitted since that could be intentional.

Happy to add a Behat test if this is considered. Thanks