### PR TITLE
Fix broken Behat tests

### DIFF
--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -57,7 +57,7 @@ Feature: Install WordPress themes
     Given a WP install
     And an empty cache
 
-    When I run `wp theme install stargazer`
+    When I run `wp theme install moina`
     Then STDOUT should contain:
       """
       Success: Installed 1 of 1 themes.
@@ -67,13 +67,13 @@ Feature: Install WordPress themes
       Using cached file
       """
 
-    When I run `wp theme uninstall stargazer`
+    When I run `wp theme uninstall moina`
     Then STDOUT should contain:
       """
       Success: Deleted 1 of 1 themes.
       """
 
-    When I run `wp theme install buntu`
+    When I run `wp theme install moina-blog`
     Then STDOUT should contain:
       """
       Success: Installed 1 of 1 themes.

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -273,78 +273,78 @@ Feature: Manage WordPress themes
 
   Scenario: Enabling and disabling a theme
   	Given a WP multisite install
-    And I run `wp theme install stargazer`
-    And I run `wp theme install buntu`
+    And I run `wp theme install moina`
+    And I run `wp theme install moina-blog`
 
     When I try `wp option get allowedthemes`
     Then the return code should be 1
     # STDERR may or may not be empty, depending on WP-CLI version.
     And STDOUT should be empty
 
-    When I run `wp theme enable buntu`
+    When I run `wp theme enable moina-blog`
     Then STDOUT should contain:
        """
-       Success: Enabled the 'Buntu' theme.
+       Success: Enabled the 'Moina Blog' theme.
        """
 
     When I run `wp option get allowedthemes`
     Then STDOUT should contain:
        """
-       'buntu' => true
+       'moina-blog' => true
        """
 
-    When I run `wp theme disable buntu`
+    When I run `wp theme disable moina-blog`
     Then STDOUT should contain:
        """
-       Success: Disabled the 'Buntu' theme.
+       Success: Disabled the 'Moina Blog' theme.
        """
 
     When I run `wp option get allowedthemes`
     Then STDOUT should not contain:
        """
-       'buntu' => true
+       'moina-blog' => true
        """
 
-    When I run `wp theme enable buntu --activate`
+    When I run `wp theme enable moina-blog --activate`
     Then STDOUT should contain:
        """
-       Success: Enabled the 'Buntu' theme.
-       Success: Switched to 'Buntu' theme.
+       Success: Enabled the 'Moina Blog' theme.
+       Success: Switched to 'Moina Blog' theme.
        """
 
     # Hybrid_Registry throws warning for PHP 8+.
     When I try `wp network-meta get 1 allowedthemes`
     Then STDOUT should not contain:
        """
-       'buntu' => true
+       'moina-blog' => true
        """
 
     # Hybrid_Registry throws warning for PHP 8+.
-    When I try `wp theme enable buntu --network`
+    When I try `wp theme enable moina-blog --network`
     Then STDOUT should contain:
        """
-       Success: Network enabled the 'Buntu' theme.
+       Success: Network enabled the 'Moina Blog' theme.
        """
 
     # Hybrid_Registry throws warning for PHP 8+.
     When I try `wp network-meta get 1 allowedthemes`
     Then STDOUT should contain:
        """
-       'buntu' => true
+       'moina-blog' => true
        """
 
     # Hybrid_Registry throws warning for PHP 8+.
-    When I try `wp theme disable buntu --network`
+    When I try `wp theme disable moina-blog --network`
     Then STDOUT should contain:
        """
-       Success: Network disabled the 'Buntu' theme.
+       Success: Network disabled the 'Moina Blog' theme.
        """
 
     # Hybrid_Registry throws warning for PHP 8+.
     When I try `wp network-meta get 1 allowedthemes`
     Then STDOUT should not contain:
        """
-       'buntu' => true
+       'moina-blog' => true
        """
 
   Scenario: Enabling and disabling a theme without multisite
@@ -382,28 +382,28 @@ Feature: Manage WordPress themes
 
   Scenario: Install and attempt to activate a child theme without its parent
     Given a WP install
-    And I run `wp theme install buntu`
-    And I run `rm -rf wp-content/themes/stargazer`
+    And I run `wp theme install moina-blog`
+    And I run `rm -rf wp-content/themes/moina`
 
-    When I try `wp theme activate buntu`
+    When I try `wp theme activate moina-blog`
     Then STDERR should contain:
       """
-      Error: The parent theme is missing. Please install the "stargazer" parent theme.
+      Error: The parent theme is missing. Please install the "moina" parent theme.
       """
     And STDOUT should be empty
     And the return code should be 1
 
   Scenario: List an active theme with its parent
     Given a WP install
-    And I run `wp theme install stargazer`
-    And I run `wp theme install --activate buntu`
+    And I run `wp theme install moina`
+    And I run `wp theme install --activate moina-blog`
 
     # Hybrid_Registry throws warning for PHP 8+.
     When I try `wp theme list --fields=name,status`
     Then STDOUT should be a table containing rows:
       | name          | status   |
-      | buntu         | active   |
-      | stargazer     | parent   |
+      | moina-blog         | active   |
+      | moina     | parent   |
 
   Scenario: When updating a theme --format should be the same when using --dry-run
     Given a WP install
@@ -472,24 +472,24 @@ Feature: Manage WordPress themes
   Scenario: Automatically install parent theme for a child theme
     Given a WP install
 
-    When I try `wp theme status stargazer`
+    When I try `wp theme status moina`
     Then STDERR should contain:
       """
-      Error: The 'stargazer' theme could not be found.
+      Error: The 'moina' theme could not be found.
       """
     And STDOUT should be empty
     And the return code should be 1
 
-    When I run `wp theme install buntu`
+    When I run `wp theme install moina-blog`
     Then STDOUT should contain:
       """
       This theme requires a parent theme. Checking if it is installed
       """
 
-    When I run `wp theme status stargazer`
+    When I run `wp theme status moina`
     Then STDOUT should contain:
       """
-      Theme stargazer details:
+      Theme moina details:
       """
     And STDERR should be empty
 


### PR DESCRIPTION
The Behat tests are breaking because the child theme `buntu` no longer exists in the theme repository.

The PR replaces `stargazer` with `moina` and `buntu` with `moina-blog` themes.

The criteria to select these themes were:
- Has a child theme
- Has support for PHP 5.6