### PR TITLE
Avoid deleting parent of active theme unless using `--force`

### DIFF
--- a/features/theme-delete.feature
+++ b/features/theme-delete.feature
@@ -50,9 +50,56 @@ Feature: Delete WordPress themes
 
     When I try the previous command again
     Then STDOUT should be:
-    """
-    Success: No themes deleted.
-    """
+      """
+      Success: No themes deleted.
+      """
+
+  Scenario: Delete all installed themes when active theme has a parent
+    Given a WP install
+    And I run `wp theme install moina-blog --activate`
+
+    When I run `wp theme list --field=name`
+    Then STDOUT should contain:
+      """
+      moina-blog
+      moina
+      """
+
+    When I try `wp theme delete moina moina-blog`
+    Then STDERR should contain:
+      """
+      Can't delete the currently active theme
+      """
+    And STDERR should contain:
+      """
+      Can't delete the parent of the currently active theme
+      """
+    And STDERR should contain:
+      """
+      Error: No themes deleted.
+      """
+
+    When I run `wp theme delete --all`
+    Then STDOUT should contain:
+      """
+      Success: Deleted
+      """
+
+    When I run `wp theme list --field=name`
+    Then STDOUT should contain:
+      """
+      moina-blog
+      moina
+      """
+
+    When I run `wp theme delete --all --force`
+    Then STDOUT should contain:
+      """
+      Success: Deleted
+      """
+
+    When I run `wp theme list --field=name`
+    Then STDOUT should be empty
 
   Scenario: Attempting to delete a theme that doesn't exist
     When I run `wp theme delete p2`

--- a/features/theme-delete.feature
+++ b/features/theme-delete.feature
@@ -57,6 +57,7 @@ Feature: Delete WordPress themes
   Scenario: Delete all installed themes when active theme has a parent
     Given a WP install
     And I run `wp theme install moina-blog --activate`
+    And I run `wp theme activate moina`
 
     When I run `wp theme list --field=name`
     Then STDOUT should contain:

--- a/features/theme-delete.feature
+++ b/features/theme-delete.feature
@@ -19,16 +19,16 @@ Feature: Delete WordPress themes
 
     When I try `wp theme delete p2`
     Then STDERR should be:
-    """
-    Warning: Can't delete the currently active theme: p2
-    Error: No themes deleted.
-    """
+      """
+      Warning: Can't delete the currently active theme: p2
+      Error: No themes deleted.
+      """
 
     When I try `wp theme delete p2 --force`
     Then STDOUT should contain:
-    """
-    Deleted 'p2' theme.
-    """
+      """
+      Deleted 'p2' theme.
+      """
 
   Scenario: Delete all installed themes
     When I run `wp theme list --status=active --field=name --porcelain`
@@ -36,9 +36,9 @@ Feature: Delete WordPress themes
 
     When I try `wp theme delete --all`
     Then STDOUT should contain:
-    """
-    Success: Deleted
-    """
+      """
+      Success: Deleted
+      """
     And STDERR should be empty
 
     When I run `wp theme delete --all --force`

--- a/features/theme-delete.feature
+++ b/features/theme-delete.feature
@@ -57,7 +57,6 @@ Feature: Delete WordPress themes
   Scenario: Delete all installed themes when active theme has a parent
     Given a WP install
     And I run `wp theme install moina-blog --activate`
-    And I run `wp theme activate moina`
 
     When I run `wp theme list --field=name`
     Then STDOUT should contain:
@@ -66,12 +65,18 @@ Feature: Delete WordPress themes
       moina
       """
 
-    When I try `wp theme delete moina moina-blog`
+    When I try `wp theme delete moina-blog`
     Then STDERR should contain:
       """
       Can't delete the currently active theme
       """
     And STDERR should contain:
+      """
+      Error: No themes deleted.
+      """
+
+    When I try `wp theme delete moina`
+    Then STDERR should contain:
       """
       Can't delete the parent of the currently active theme
       """

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -782,6 +782,14 @@ class Theme_Command extends CommandWithUpgrade {
 				continue;
 			}
 
+			if ( $this->is_active_parent_theme( $theme ) && ! $force ) {
+				if ( ! $all ) {
+					WP_CLI::warning( "Can't delete the parent of the currently active theme: $theme_slug" );
+					$errors++;
+				}
+				continue;
+			}
+
 			$r = delete_theme( $theme_slug );
 
 			if ( is_wp_error( $r ) ) {

--- a/src/WP_CLI/ParseThemeNameInput.php
+++ b/src/WP_CLI/ParseThemeNameInput.php
@@ -159,6 +159,17 @@ trait ParseThemeNameInput {
 	}
 
 	/**
+	 * Check whether a given theme is the active theme parent.
+	 *
+	 * @param string $theme Theme to check.
+	 *
+	 * @return bool Whether the provided theme is the active theme.
+	 */
+	protected function is_active_parent_theme( $theme ) {
+		return $theme->get_stylesheet_directory() === get_template_directory();
+	}
+
+	/**
 	 * Get the available update info.
 	 *
 	 * @return mixed Available update info.


### PR DESCRIPTION
Fixes https://github.com/wp-cli/extension-command/issues/323
Fixes https://github.com/wp-cli/extension-command/issues/325