### PR TITLE
Don't report an error when 5 out of 5 plugins were updated

### DIFF
--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -239,7 +239,7 @@ Feature: Update WordPress plugins
     When I run `wp plugin install wordpress-importer --version=0.5`
     Then STDOUT should not be empty
 
-    When I run `sed -i bak 's/Version: .*/Version: 10000/' $(wp plugin path health-check)`
+    When I run `sed -ibak 's/Version: .*/Version: 10000/' $(wp plugin path health-check)`
     Then STDOUT should be empty
     And the return code should be 0
 

--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -239,7 +239,7 @@ Feature: Update WordPress plugins
     When I run `wp plugin install wordpress-importer --version=0.5`
     Then STDOUT should not be empty
 
-    When I run `sed -ibak 's/Version: .*/Version: 10000/' $(wp plugin path health-check)`
+    When I run `sed -i.bak 's/Version: .*/Version: 10000/' $(wp plugin path health-check)`
     Then STDOUT should be empty
     And the return code should be 0
 

--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -228,3 +228,33 @@ Feature: Update WordPress plugins
       Success:
       """
     And the return code should be 0
+
+
+  Scenario: Updating all plugins with some of them having an invalid version shouldn't report an error
+    Given a WP install
+
+    When I run `wp plugin install health-check --version=1.5.0`
+    Then STDOUT should not be empty
+
+    When I run `wp plugin install wordpress-importer --version=0.5`
+    Then STDOUT should not be empty
+
+    When I run `sed -i bak 's/Version: .*/Version: 10000/' $(wp plugin path health-check)`
+    Then STDOUT should be empty
+    And the return code should be 0
+
+    When I try `wp plugin update --all`
+    Then STDERR should contain:
+      """
+      Warning: health-check: version higher than expected.
+      """
+
+    And STDOUT should not contain:
+      """
+      Error: Only updated 1 of 1 plugins.
+      """
+
+    And STDOUT should contain:
+      """
+      Success: Updated 1 of 1 plugins (1 skipped).
+      """

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -159,7 +159,7 @@ Feature: Manage WordPress plugins
       """
     And STDERR should contain:
       """
-      Error: No plugins updated.
+      Error: No plugins updated (2 failed).
       """
     And the return code should be 1
 
@@ -177,7 +177,7 @@ Feature: Manage WordPress plugins
       """
     And STDERR should contain:
       """
-      Error: Only updated 1 of 3 plugins.
+      Error: Only updated 1 of 3 plugins (2 failed).
       """
     And the return code should be 1
 

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -480,7 +480,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		$total_updated = Utils\get_flag_value( $assoc_args, 'all' ) ? $num_to_update : count( $args );
 		if ( 0 === $num_updated && $skipped ) {
-			$errors = $skipped;
+			$errors  = $skipped;
 			$skipped = null;
 		}
 		Utils\report_batch_operation_results( $this->item_type, 'update', $total_updated, $num_updated, $errors, $skipped );

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -335,6 +335,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		$items = $this->get_item_list();
 
 		$errors = 0;
+		$skipped = 0;
 		if ( ! Utils\get_flag_value( $assoc_args, 'all' ) ) {
 			$items  = $this->filter_item_list( $items, $args );
 			$errors = count( $args ) - count( $items );
@@ -378,7 +379,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		foreach ( $items_to_update as $item_key => $item_info ) {
 			if ( static::INVALID_VERSION_MESSAGE === $item_info['update'] ) {
 				WP_CLI::warning( "{$item_info['name']}: " . static::INVALID_VERSION_MESSAGE . '.' );
-				$errors++;
+				$skipped++;
 				unset( $items_to_update[ $item_key ] );
 			}
 		}
@@ -478,7 +479,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		}
 
 		$total_updated = Utils\get_flag_value( $assoc_args, 'all' ) ? $num_to_update : count( $args );
-		Utils\report_batch_operation_results( $this->item_type, 'update', $total_updated, $num_updated, $errors );
+		Utils\report_batch_operation_results( $this->item_type, 'update', $total_updated, $num_updated, $errors, $skipped );
 		if ( null !== $exclude ) {
 			WP_CLI::log( "Skipped updates for: $exclude" );
 		}

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -334,7 +334,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		$items = $this->get_item_list();
 
-		$errors = 0;
+		$errors  = 0;
 		$skipped = 0;
 		if ( ! Utils\get_flag_value( $assoc_args, 'all' ) ) {
 			$items  = $this->filter_item_list( $items, $args );

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -479,6 +479,10 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		}
 
 		$total_updated = Utils\get_flag_value( $assoc_args, 'all' ) ? $num_to_update : count( $args );
+		if ( 0 === $num_updated && $skipped ) {
+			$errors = $skipped;
+			$skipped = null;
+		}
 		Utils\report_batch_operation_results( $this->item_type, 'update', $total_updated, $num_updated, $errors, $skipped );
 		if ( null !== $exclude ) {
 			WP_CLI::log( "Skipped updates for: $exclude" );


### PR DESCRIPTION
Currently, if you've got (unreleased) plugins with an unexpected version they are skipped but this skipping is recorded in a wrong way resulting in a summary output that says `Error: Only updated 5 of 5 plugins.`

#### Before
<img width="562" alt="Screenshot 2022-11-09 at 11 41 46" src="https://user-images.githubusercontent.com/203408/200914755-f230166d-b453-41ee-ab35-d87c32e739e8.png">

#### After
<img width="554" alt="Screenshot 2022-11-09 at 11 42 27" src="https://user-images.githubusercontent.com/203408/200914817-abb10a55-ac72-4187-a54e-78b58b820070.png">
