### PR TITLE
Delete plugin translation files when plugin is uninstalled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require-dev": {
         "wp-cli/cache-command": "^2.0",
         "wp-cli/entity-command": "^1.3 || ^2",
+        "wp-cli/language-command": "^2.0",
         "wp-cli/scaffold-command": "^1.2 || ^2",
         "wp-cli/wp-cli-tests": "^3.1"
     },

--- a/features/plugin-uninstall.feature
+++ b/features/plugin-uninstall.feature
@@ -91,3 +91,26 @@ Feature: Uninstall a WordPress plugin
       Success:
       """
     And the return code should be 0
+
+  @requires-wp-5.2
+  Scenario: Uninstalling a plugin should remove its language pack too
+    Given a WP install
+    And I run `wp plugin install wordpress-importer`
+    And I run `wp core language install fr_FR`
+    And I run `wp site switch-language fr_FR`
+
+    When I run `wp language plugin install wordpress-importer fr_FR`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+    And the wp-content/languages/plugins/wordpress-importer-fr_FR.mo file should exist
+    And the wp-content/languages/plugins/wordpress-importer-fr_FR.po file should exist
+
+    When I run `wp plugin uninstall wordpress-importer`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+    And the wp-content/languages/plugins/wordpress-importer-fr_FR.mo file should not exist
+    And the wp-content/languages/plugins/wordpress-importer-fr_FR.po file should not exist

--- a/features/plugin-uninstall.feature
+++ b/features/plugin-uninstall.feature
@@ -92,7 +92,7 @@ Feature: Uninstall a WordPress plugin
       """
     And the return code should be 0
 
-  @requires-wp-5.2
+  @require-wp-5.2
   Scenario: Uninstalling a plugin should remove its language pack too
     Given a WP install
     And I run `wp plugin install wordpress-importer`

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -967,7 +967,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				$translations = $plugin_translations[ $plugin_slug ];
 
 				global $wp_filesystem;
-				require_once ( ABSPATH . '/wp-admin/includes/file.php' );
+				require_once ABSPATH . '/wp-admin/includes/file.php';
 				WP_Filesystem();
 
 				foreach ( $translations as $translation => $data ) {

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -951,8 +951,37 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				$this->deactivate( array( $plugin->name ) );
 				$this->chained_command = false;
 			}
+			
+			if ( is_uninstallable_plugin( $plugin->file ) ) {
+				uninstall_plugin( $plugin->file );
 
-			uninstall_plugin( $plugin->file );
+				$plugin_translations = wp_get_installed_translations( 'plugins' );
+
+				$plugin_slug = dirname( $plugin->file );
+
+				if ( 'hello.php' === $plugin->file ) {
+					$plugin_slug = 'hello-dolly';
+				}
+
+				// Remove language files, silently.
+				if ( '.' !== $plugin_slug && ! empty( $plugin_translations[ $plugin_slug ] ) ) {
+					$translations = $plugin_translations[ $plugin_slug ];
+
+					global $wp_filesystem;
+					require_once ( ABSPATH . '/wp-admin/includes/file.php' );
+					WP_Filesystem();
+
+					foreach ( $translations as $translation => $data ) {
+						$wp_filesystem->delete( WP_LANG_DIR . '/plugins/' . $plugin_slug . '-' . $translation . '.po' );
+						$wp_filesystem->delete( WP_LANG_DIR . '/plugins/' . $plugin_slug . '-' . $translation . '.mo' );
+
+						$json_translation_files = glob( WP_LANG_DIR . '/plugins/' . $plugin_slug . '-' . $translation . '-*.json' );
+						if ( $json_translation_files ) {
+							array_map( array( $wp_filesystem, 'delete' ), $json_translation_files );
+						}
+					}
+				}
+			}
 
 			if ( ! Utils\get_flag_value( $assoc_args, 'skip-delete' ) && $this->delete_plugin( $plugin ) ) {
 				WP_CLI::log( "Uninstalled and deleted '$plugin->name' plugin." );

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -951,34 +951,32 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				$this->deactivate( array( $plugin->name ) );
 				$this->chained_command = false;
 			}
-			
-			if ( is_uninstallable_plugin( $plugin->file ) ) {
-				uninstall_plugin( $plugin->file );
 
-				$plugin_translations = wp_get_installed_translations( 'plugins' );
+			uninstall_plugin( $plugin->file );
 
-				$plugin_slug = dirname( $plugin->file );
+			$plugin_translations = wp_get_installed_translations( 'plugins' );
 
-				if ( 'hello.php' === $plugin->file ) {
-					$plugin_slug = 'hello-dolly';
-				}
+			$plugin_slug = dirname( $plugin->file );
 
-				// Remove language files, silently.
-				if ( '.' !== $plugin_slug && ! empty( $plugin_translations[ $plugin_slug ] ) ) {
-					$translations = $plugin_translations[ $plugin_slug ];
+			if ( 'hello.php' === $plugin->file ) {
+				$plugin_slug = 'hello-dolly';
+			}
 
-					global $wp_filesystem;
-					require_once ( ABSPATH . '/wp-admin/includes/file.php' );
-					WP_Filesystem();
+			// Remove language files, silently.
+			if ( '.' !== $plugin_slug && ! empty( $plugin_translations[ $plugin_slug ] ) ) {
+				$translations = $plugin_translations[ $plugin_slug ];
 
-					foreach ( $translations as $translation => $data ) {
-						$wp_filesystem->delete( WP_LANG_DIR . '/plugins/' . $plugin_slug . '-' . $translation . '.po' );
-						$wp_filesystem->delete( WP_LANG_DIR . '/plugins/' . $plugin_slug . '-' . $translation . '.mo' );
+				global $wp_filesystem;
+				require_once ( ABSPATH . '/wp-admin/includes/file.php' );
+				WP_Filesystem();
 
-						$json_translation_files = glob( WP_LANG_DIR . '/plugins/' . $plugin_slug . '-' . $translation . '-*.json' );
-						if ( $json_translation_files ) {
-							array_map( array( $wp_filesystem, 'delete' ), $json_translation_files );
-						}
+				foreach ( $translations as $translation => $data ) {
+					$wp_filesystem->delete( WP_LANG_DIR . '/plugins/' . $plugin_slug . '-' . $translation . '.po' );
+					$wp_filesystem->delete( WP_LANG_DIR . '/plugins/' . $plugin_slug . '-' . $translation . '.mo' );
+
+					$json_translation_files = glob( WP_LANG_DIR . '/plugins/' . $plugin_slug . '-' . $translation . '-*.json' );
+					if ( $json_translation_files ) {
+						array_map( array( $wp_filesystem, 'delete' ), $json_translation_files );
 					}
 				}
 			}


### PR DESCRIPTION
### Summary

Currently, plugin translation files are not deleted from `/wp-content/languages/plugins` when a plugin is uninstalled using wp-cli.
With these changes, file translation files will also be deleted when a plugin is uninstalled.

### Testing instructions

1. Install a plugin using the following command: `wp plugin install [PLUGIN-NAME]`
2. Install translation files for the plugin you installed: `wp language plugin install [PLUGIN-NAME] [language]`

Example:
> wp plugin install duplicator.
> wp language plugin install duplicator fr_FR.

Access `/wp-content/languages/plugins` and verify you see the language files for the plugin you installed.
> duplicator-fr_FR.mo
> duplicator-fr_FR.po

3. Uninstall the plugin using `wp plugin uninstall [PLUGIN-NAME]`.
4. Verify the language files no longer exist in the plugins folder.



Fixes #337 