### PR TITLE
Fix failing PHP 5.6 tests by requiring WP 5.2

### DIFF
--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -1,5 +1,6 @@
 Feature: Update WordPress plugins
 
+  @require-wp-5.2
   Scenario: Updating plugin with invalid version shouldn't remove the old version
     Given a WP install
 
@@ -45,6 +46,7 @@ Feature: Update WordPress plugins
       """
     And the return code should be 1
 
+  @require-wp-5.2
   Scenario: Exclude plugin updates from bulk updates.
     Given a WP install
 
@@ -76,6 +78,7 @@ Feature: Update WordPress plugins
       Update available
       """
 
+  @require-wp-5.2
   Scenario: Update a plugin to its latest patch release
     Given a WP install
     And I run `wp plugin install --force wordpress-importer --version=0.5`
@@ -109,6 +112,7 @@ Feature: Update WordPress plugins
       2.6.1
       """
 
+  @require-wp-5.2
   Scenario: Not giving a slug on update should throw an error unless --all given
     Given a WP install
     And I run `wp plugin path`
@@ -229,7 +233,7 @@ Feature: Update WordPress plugins
       """
     And the return code should be 0
 
-
+  @require-wp-5.2
   Scenario: Updating all plugins with some of them having an invalid version shouldn't report an error
     Given a WP install
 

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -341,6 +341,7 @@ Feature: Manage WordPress plugins
       | akismet            | active   | akismet/akismet.php                       |
       | wordpress-importer | inactive | wordpress-importer/wordpress-importer.php |
 
+  @require-wp-5.2
   Scenario: Flag `--skip-update-check` skips update check when running `wp plugin list`
     Given a WP install
 


### PR DESCRIPTION
The WordPress importer changed its minimum supported WP version to 5.2, which means these tests never receive an update offer in WP 3.7.

It looks like all "official" plugins no longer support WP 3.7, so there isn't really anything we can replace with.
