### PR TITLE
Avoid deleting theme if the specified version cannot be found

### DIFF
--- a/features/theme-update.feature
+++ b/features/theme-update.feature
@@ -16,3 +16,100 @@ Feature: Update WordPress themes
       Error: No themes installed
       """
     And the wp-content/themes/wpclitesttheme directory should exist
+
+  Scenario: Install a theme, then update to a specific version of that theme
+    Given a WP install
+
+    When I run `wp theme install p2 --version=1.4.1`
+    Then STDOUT should not be empty
+
+    When I run `wp theme update p2 --version=1.4.2`
+    Then STDOUT should not be empty
+
+    When I run `wp theme list --fields=name,version`
+    Then STDOUT should be a table containing rows:
+      | name       | version   |
+      | p2         | 1.4.2     |
+
+  Scenario: Not giving a slug on update should throw an error unless --all given
+    Given a WP install
+    And I run `wp theme path`
+    And save STDOUT as {THEME_DIR}
+    And an empty {THEME_DIR} directory
+
+    # No themes installed. Don't give an error if --all given for BC.
+    When I run `wp theme update --all`
+    Then STDOUT should be:
+      """
+      Success: No themes installed.
+      """
+
+    When I run `wp theme update --version=0.6 --all`
+    Then STDOUT should be:
+      """
+      Success: No themes installed.
+      """
+
+    # One theme installed.
+    Given I run `wp theme install p2 --version=1.4.2`
+
+    When I try `wp theme update`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: Please specify one or more themes, or use --all.
+      """
+    And STDOUT should be empty
+
+    When I run `wp theme update --all`
+    Then STDOUT should contain:
+      """
+      Success: Updated
+      """
+
+    When I run the previous command again
+    Then STDOUT should be:
+      """
+      Success: Theme already updated.
+      """
+
+    # Note: if given version then re-installs.
+    When I run `wp theme update --version=1.4.2 --all`
+    Then STDOUT should contain:
+      """
+      Success: Installed 1 of 1 themes.
+      """
+
+    When I run the previous command again
+    Then STDOUT should contain:
+      """
+      Success: Installed 1 of 1 themes.
+      """
+
+    # Two themes installed.
+    Given I run `wp theme install --force twentytwelve --version=1.0`
+
+    When I run `wp theme update --all`
+    Then STDOUT should contain:
+      """
+      Success: Updated
+      """
+
+    When I run the previous command again
+    # BUG: Message should be in plural.
+    Then STDOUT should be:
+      """
+      Success: Theme already updated.
+      """
+
+    # Using version with all rarely makes sense and should probably error and do nothing.
+    When I try `wp theme update --version=1.4.2 --all`
+    Then the return code should be 1
+    And STDOUT should contain:
+      """
+      Success: Installed 1 of 1 themes.
+      """
+    And STDERR should be:
+      """
+      Error: Can't find the requested theme's version 1.4.2 in the WordPress.org theme repository (HTTP code 404).
+      """

--- a/features/theme-update.feature
+++ b/features/theme-update.feature
@@ -1,0 +1,18 @@
+Feature: Update WordPress themes
+
+  Scenario: Updating a theme with no version in the WordPress.org directory shouldn't delete the original theme
+    Given a WP install
+
+    When I run `wp scaffold underscores wpclitesttheme`
+    Then STDOUT should contain:
+      """
+      Success: Created theme
+      """
+    And the wp-content/themes/wpclitesttheme directory should exist
+
+    When I try `wp theme update wpclitesttheme --version=100.0.0`
+    Then STDERR should contain:
+      """
+      Error: No themes installed
+      """
+    And the wp-content/themes/wpclitesttheme directory should exist

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -366,20 +366,6 @@ Feature: Manage WordPress themes
     And STDOUT should be empty
     And the return code should be 1
 
-  Scenario: Install a theme, then update to a specific version of that theme
-    Given a WP install
-
-    When I run `wp theme install p2 --version=1.4.1`
-    Then STDOUT should not be empty
-
-    When I run `wp theme update p2 --version=1.4.2`
-    Then STDOUT should not be empty
-
-    When I run `wp theme list --fields=name,version`
-    Then STDOUT should be a table containing rows:
-      | name       | version   |
-      | p2         | 1.4.2     |
-
   Scenario: Install and attempt to activate a child theme without its parent
     Given a WP install
     And I run `wp theme install moina-blog`
@@ -492,89 +478,6 @@ Feature: Manage WordPress themes
       Theme moina details:
       """
     And STDERR should be empty
-
-  Scenario: Not giving a slug on update should throw an error unless --all given
-    Given a WP install
-    And I run `wp theme path`
-    And save STDOUT as {THEME_DIR}
-    And an empty {THEME_DIR} directory
-
-    # No themes installed. Don't give an error if --all given for BC.
-    When I run `wp theme update --all`
-    Then STDOUT should be:
-      """
-      Success: No themes installed.
-      """
-
-    When I run `wp theme update --version=0.6 --all`
-    Then STDOUT should be:
-      """
-      Success: No themes installed.
-      """
-
-    # One theme installed.
-    Given I run `wp theme install p2 --version=1.4.2`
-
-    When I try `wp theme update`
-    Then the return code should be 1
-    And STDERR should be:
-      """
-      Error: Please specify one or more themes, or use --all.
-      """
-    And STDOUT should be empty
-
-    When I run `wp theme update --all`
-    Then STDOUT should contain:
-      """
-      Success: Updated
-      """
-
-    When I run the previous command again
-    Then STDOUT should be:
-      """
-      Success: Theme already updated.
-      """
-
-    # Note: if given version then re-installs.
-    When I run `wp theme update --version=1.4.2 --all`
-    Then STDOUT should contain:
-      """
-      Success: Installed 1 of 1 themes.
-      """
-
-    When I run the previous command again
-    Then STDOUT should contain:
-      """
-      Success: Installed 1 of 1 themes.
-      """
-
-    # Two themes installed.
-    Given I run `wp theme install --force twentytwelve --version=1.0`
-
-    When I run `wp theme update --all`
-    Then STDOUT should contain:
-      """
-      Success: Updated
-      """
-
-    When I run the previous command again
-    # BUG: Message should be in plural.
-    Then STDOUT should be:
-      """
-      Success: Theme already updated.
-      """
-
-    # Using version with all rarely makes sense and should probably error and do nothing.
-    When I try `wp theme update --version=1.4.2 --all`
-    Then the return code should be 1
-    And STDOUT should contain:
-      """
-      Success: Installed 1 of 1 themes.
-      """
-    And STDERR should be:
-      """
-      Error: Can't find the requested theme's version 1.4.2 in the WordPress.org theme repository (HTTP code 404).
-      """
 
   Scenario: Get status field in theme detail
     Given a WP install

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -663,13 +663,8 @@ class Theme_Command extends CommandWithUpgrade {
 
 		if ( isset( $assoc_args['version'] ) ) {
 			foreach ( $this->fetcher->get_many( $args ) as $theme ) {
-				$r = delete_theme( $theme->stylesheet );
-				if ( is_wp_error( $r ) ) {
-					WP_CLI::warning( $r );
-				} else {
-					$assoc_args['force'] = true;
-					$this->install( array( $theme->stylesheet ), $assoc_args );
-				}
+				$assoc_args['force'] = true;
+				$this->install( array( $theme->stylesheet ), $assoc_args );
 			}
 		} else {
 			parent::update_many( $args, $assoc_args );


### PR DESCRIPTION
Fixes https://github.com/wp-cli/extension-command/issues/144

The "delete before install" behavior was originally added in https://github.com/wp-cli/wp-cli/pull/1510

Interestingly, it doesn't appear necessary and may have been copy paste from the `wp plugin update` code.

Seems like it should be fine to remove if all of the existing tests pass. I moved a few other relevant tests into my new feature file.