### PR TITLE
Include optional 'auto_updates' field in plugin and theme lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ These fields are optionally available:
 * title
 * description
 * file
+* auto_update
 
 **EXAMPLES**
 
@@ -1064,6 +1065,7 @@ These fields are optionally available:
 * update_id
 * title
 * description
+* auto_update
 
 **EXAMPLES**
 

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -696,3 +696,16 @@ Feature: Manage WordPress plugins
     Then STDOUT should be a table containing rows:
       | name    | title             | description                                    |
       | test-mu | Test mu-plugin    | Test mu-plugin description                     |
+
+  Scenario: Listing plugins should include name and auto_updates
+    Given a WP install
+    When I run `wp plugin list --fields=name,auto_updates`
+    Then STDOUT should be a table containing rows:
+      | name              | auto_updates         |
+      | hello             | off                  |
+
+    When I run `wp plugin auto-updates enable hello`
+    And I try `wp plugin list --fields=name,auto_updates`
+    Then STDOUT should be a table containing rows:
+      | name              | auto_updates         |
+      | hello             | on                   |

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -698,15 +698,15 @@ Feature: Manage WordPress plugins
       | test-mu | Test mu-plugin    | Test mu-plugin description                     |
 
   @require-wp-5.5
-  Scenario: Listing plugins should include name and auto_updates
+  Scenario: Listing plugins should include name and auto_update
     Given a WP install
-    When I run `wp plugin list --fields=name,auto_updates`
+    When I run `wp plugin list --fields=name,auto_update`
     Then STDOUT should be a table containing rows:
-      | name              | auto_updates         |
+      | name              | auto_update          |
       | hello             | off                  |
 
     When I run `wp plugin auto-updates enable hello`
-    And I try `wp plugin list --fields=name,auto_updates`
+    And I try `wp plugin list --fields=name,auto_update`
     Then STDOUT should be a table containing rows:
-      | name              | auto_updates         |
+      | name              | auto_update          |
       | hello             | on                   |

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -697,6 +697,7 @@ Feature: Manage WordPress plugins
       | name    | title             | description                                    |
       | test-mu | Test mu-plugin    | Test mu-plugin description                     |
 
+  @require-wp-5.5
   Scenario: Listing plugins should include name and auto_updates
     Given a WP install
     When I run `wp plugin list --fields=name,auto_updates`

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -687,15 +687,15 @@ Feature: Manage WordPress themes
     And the return code should be 0
 
   @require-wp-5.5
-  Scenario: Listing themes should include auto_updates
+  Scenario: Listing themes should include auto_update
     Given a WP install
-    When I run `wp theme list --fields=auto_updates`
+    When I run `wp theme list --fields=auto_update`
     Then STDOUT should be a table containing rows:
-      | auto_updates         |
+      | auto_update          |
       | off                  |
 
     When I run `wp theme auto-updates enable --all`
-    And I try `wp theme list --fields=auto_updates`
+    And I try `wp theme list --fields=auto_update`
     Then STDOUT should be a table containing rows:
-      | auto_updates         |
+      | auto_update          |
       | on                   |

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -685,3 +685,16 @@ Feature: Manage WordPress themes
       Success:
       """
     And the return code should be 0
+
+  Scenario: Listing themes should include auto_updates
+    Given a WP install
+    When I run `wp theme list --fields=auto_updates`
+    Then STDOUT should be a table containing rows:
+      | auto_updates         |
+      | off                  |
+
+    When I run `wp theme auto-updates enable --all`
+    And I try `wp theme list --fields=auto_updates`
+    Then STDOUT should be a table containing rows:
+      | auto_updates         |
+      | on                   |

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -686,6 +686,7 @@ Feature: Manage WordPress themes
       """
     And the return code should be 0
 
+  @require-wp-5.5
   Scenario: Listing themes should include auto_updates
     Given a WP install
     When I run `wp theme list --fields=auto_updates`

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1183,6 +1183,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * * title
 	 * * description
 	 * * file
+	 * * auto_update
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -255,7 +255,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'title'          => $mu_title,
 				'description'    => $mu_description,
 				'file'           => $file,
-				'auto_updates'   => false,
+				'auto_update'    => false,
 			);
 		}
 
@@ -273,7 +273,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'update_package' => null,
 				'update_id'      => '',
 				'file'           => $name,
-				'auto_updates'   => false,
+				'auto_update'    => false,
 			];
 		}
 
@@ -719,7 +719,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'title'          => $details['Name'],
 				'description'    => wordwrap( $details['Description'] ),
 				'file'           => $file,
-				'auto_updates'   => in_array( $file, $auto_updates, true ),
+				'auto_update'    => in_array( $file, $auto_updates, true ),
 			];
 
 			if ( null === $update_info ) {

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -255,6 +255,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'title'          => $mu_title,
 				'description'    => $mu_description,
 				'file'           => $file,
+				'auto_updates'   => false,
 			);
 		}
 
@@ -272,6 +273,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'update_package' => null,
 				'update_id'      => '',
 				'file'           => $name,
+				'auto_updates'   => false,
 			];
 		}
 
@@ -690,6 +692,12 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		$items           = [];
 		$duplicate_names = [];
 
+		$auto_updates = get_site_option( Plugin_AutoUpdates_Command::SITE_OPTION );
+
+		if ( false === $auto_updates ) {
+			$auto_updates = [];
+		}
+
 		foreach ( $this->get_all_plugins() as $file => $details ) {
 			$all_update_info = $this->get_update_info();
 			$update_info     = ( isset( $all_update_info->response[ $file ] ) && null !== $all_update_info->response[ $file ] ) ? (array) $all_update_info->response[ $file ] : null;
@@ -711,6 +719,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'title'          => $details['Name'],
 				'description'    => wordwrap( $details['Description'] ),
 				'file'           => $file,
+				'auto_updates'   => in_array( $file, $auto_updates, true ),
 			];
 
 			if ( null === $update_info ) {

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -859,6 +859,7 @@ class Theme_Command extends CommandWithUpgrade {
 	 * * update_id
 	 * * title
 	 * * description
+	 * * auto_update
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -516,7 +516,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 					} elseif ( false === $value ) {
 						$value = 'none';
 					}
-				} elseif ( 'auto_updates' === $field ) {
+				} elseif ( 'auto_update' === $field ) {
 					if ( true === $value ) {
 						$value = 'on';
 					} elseif ( false === $value ) {

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -510,10 +510,18 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			}
 
 			foreach ( $item as $field => &$value ) {
-				if ( true === $value ) {
-					$value = 'available';
-				} elseif ( false === $value ) {
-					$value = 'none';
+				if ( 'update' === $field ) {
+					if ( true === $value ) {
+						$value = 'available';
+					} elseif ( false === $value ) {
+						$value = 'none';
+					}
+				} elseif ( 'auto_updates' === $field ) {
+					if ( true === $value ) {
+						$value = 'on';
+					} elseif ( false === $value ) {
+						$value = 'off';
+					}
 				}
 			}
 

--- a/src/WP_CLI/ParseThemeNameInput.php
+++ b/src/WP_CLI/ParseThemeNameInput.php
@@ -3,6 +3,7 @@
 namespace WP_CLI;
 
 use WP_CLI;
+use Theme_AutoUpdates_Command;
 
 trait ParseThemeNameInput {
 
@@ -68,6 +69,12 @@ trait ParseThemeNameInput {
 			}
 		}
 
+		$auto_updates = get_site_option( Theme_AutoUpdates_Command::SITE_OPTION );
+
+		if ( false === $auto_updates ) {
+			$auto_updates = [];
+		}
+
 		foreach ( wp_get_themes() as $key => $theme ) {
 			$file = $theme->get_stylesheet_directory();
 
@@ -84,6 +91,7 @@ trait ParseThemeNameInput {
 				'title'          => $theme->get( 'Name' ),
 				'description'    => wordwrap( $theme->get( 'Description' ) ),
 				'author'         => $theme->get( 'Author' ),
+				'auto_updates'   => in_array( $theme->get_stylesheet(), $auto_updates, true ),
 			];
 
 			// Compare version and update information in theme list.

--- a/src/WP_CLI/ParseThemeNameInput.php
+++ b/src/WP_CLI/ParseThemeNameInput.php
@@ -91,7 +91,7 @@ trait ParseThemeNameInput {
 				'title'          => $theme->get( 'Name' ),
 				'description'    => wordwrap( $theme->get( 'Description' ) ),
 				'author'         => $theme->get( 'Author' ),
-				'auto_updates'   => in_array( $theme->get_stylesheet(), $auto_updates, true ),
+				'auto_update'    => in_array( $theme->get_stylesheet(), $auto_updates, true ),
 			];
 
 			// Compare version and update information in theme list.


### PR DESCRIPTION
Fixes #344 

This pull request adds an optional field to the `wp plugin list` and `wp theme list` command. With this change, users can now display the `auto_updates` column when listing plugins or themes by using the `--field` option, like this:

 `wp plugin list --field=name,auto_updates` or
 `wp theme list --field=name,auto_updates` --format=json

I've also updated the test suite with a test case for this scenario.

Note: This is my first contribution to this project. I'd greatly appreciate any feedback or suggestions on how I can improve my code and my contribution process. Thank you for considering this pull request!
