### PR TITLE
Add format option to wp plugin|theme auto-updates status

### DIFF
--- a/features/plugin-auto-updates-status.feature
+++ b/features/plugin-auto-updates-status.feature
@@ -97,3 +97,21 @@ Feature: Show the status of auto-updates for WordPress plugins
       """
       enabled
       """
+
+  @require-wp-5.5
+  Scenario: Formatting options work
+
+    When I run `wp plugin auto-updates status --all --format=json`
+    Then STDOUT should be:
+      """
+      [{"name":"akismet","status":"disabled"},{"name":"hello","status":"disabled"},{"name":"duplicate-post","status":"disabled"}]
+      """
+
+    When I run `wp plugin auto-updates status --all --format=csv`
+    Then STDOUT should be:
+      """
+      name,status
+      akismet,disabled
+      hello,disabled
+      duplicate-post,disabled
+      """

--- a/features/theme-auto-update-status.feature
+++ b/features/theme-auto-update-status.feature
@@ -100,3 +100,21 @@ Feature: Show the status of auto-updates for WordPress themes
       """
       enabled
       """
+
+  @require-wp-5.5
+  Scenario: Formatting options work
+
+    When I run `wp theme auto-updates status --all --format=json`
+    Then STDOUT should be:
+      """
+      [{"name":"twentynineteen","status":"disabled"},{"name":"twentyseventeen","status":"disabled"},{"name":"twentysixteen","status":"disabled"}]
+      """
+
+    When I run `wp theme auto-updates status --all --format=csv`
+    Then STDOUT should be:
+      """
+      name,status
+      twentynineteen,disabled
+      twentyseventeen,disabled
+      twentysixteen,disabled
+      """

--- a/src/Plugin_AutoUpdates_Command.php
+++ b/src/Plugin_AutoUpdates_Command.php
@@ -231,6 +231,18 @@ class Plugin_AutoUpdates_Command {
 	 * [--field=<field>]
 	 * : Only show the provided field.
 	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 *   - count
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Get the status of plugin auto-updates

--- a/src/Theme_AutoUpdates_Command.php
+++ b/src/Theme_AutoUpdates_Command.php
@@ -236,11 +236,11 @@ class Theme_AutoUpdates_Command {
 	 * ---
 	 * default: table
 	 * options:
- 	 *   - table
- 	 *   - csv
- 	 *   - json
- 	 *   - yaml
- 	 *   - count
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 *   - count
 	 * ---
 	 *
 	 * ## EXAMPLES

--- a/src/Theme_AutoUpdates_Command.php
+++ b/src/Theme_AutoUpdates_Command.php
@@ -231,6 +231,18 @@ class Theme_AutoUpdates_Command {
 	 * [--field=<field>]
 	 * : Only show the provided field.
 	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+ 	 *   - table
+ 	 *   - csv
+ 	 *   - json
+ 	 *   - yaml
+ 	 *   - count
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Get the status of theme auto-updates


### PR DESCRIPTION
Add --format option to `wp (plugin|theme) auto-updates status` as requested by user here: https://wordpress.slack.com/archives/C02RP4T41/p1675804802225149

I looked at replacing direct use of `Formatter` with https://make.wordpress.org/cli/handbook/references/internal-api/wp-cli-utils-format-items/ but it does not seem to support the singular `--field` option


https://github.com/wp-cli/wp-cli/blob/89be15b87bb3c496841b2362975fe0d8ddd8ed21/php/utils.php#L334-L338