### PR TITLE
Replace empty namespace autoloader with classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,9 +76,9 @@
         ]
     },
     "autoload": {
-        "psr-4": {
-            "": "src/"
-        },
+        "classmap": [
+            "src/"
+        ],
         "files": [
             "extension-command.php"
         ]


### PR DESCRIPTION
This fixes the issue described here: https://github.com/wp-cli/wp-cli/issues/5731