### PR TITLE
Fix fatal error in invalid plugin update offer

### DIFF
--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -629,7 +629,11 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			$update_version = false;
 			$update_package = false;
 			foreach ( $data['versions'] as $version => $download_link ) {
-				$update_type = Utils\get_named_sem_ver( $version, $item['version'] );
+				try {
+					$update_type = Utils\get_named_sem_ver( $version, $item['version'] );
+				} catch (\Exception $e) {
+					continue;
+				}
 				// Compared version must be older.
 				if ( ! $update_type ) {
 					continue;

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -631,7 +631,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			foreach ( $data['versions'] as $version => $download_link ) {
 				try {
 					$update_type = Utils\get_named_sem_ver( $version, $item['version'] );
-				} catch (\Exception $e) {
+				} catch ( \Exception $e ) {
 					continue;
 				}
 				// Compared version must be older.


### PR DESCRIPTION
Fixes https://github.com/wp-cli/extension-command/issues/292

I don't want to add feature tests for this because I don't want to pin tests to an outdated version of Elementor that probably won't survive WP and PHP version updates.

With the pull request:

```bash
$ wp plugin install elementor --version=3.1.4 --force
Installing Elementor Website Builder (3.1.4)
Success: Installed 1 of 1 plugins.
$ wp plugin update elementor --patch
Success: Plugin already updated.
$ wp plugin update elementor --minor
Plugin updated successfully.
+-----------+-------------+-------------+---------+
| name      | old_version | new_version | status  |
+-----------+-------------+-------------+---------+
| elementor | 3.1.4       | 3.11.2      | Updated |
+-----------+-------------+-------------+---------+
Success: Updated 1 of 1 plugins.
```

Without the pull request:

```bash
$ wp plugin install elementor --version=3.1.4 --force
Installing Elementor Website Builder (3.1.4)
Success: Installed 1 of 1 plugins.
$ wp plugin update elementor --patch
Fatal error: Uncaught UnexpectedValueException: Invalid version string "3.10.0-dev1" in /Users/danielbachhuber/projects/wp-cli-dev/vendor/composer/semver/src/VersionParser.php:186
Stack trace:
#0 /Users/danielbachhuber/projects/wp-cli-dev/vendor/composer/semver/src/Semver.php(39): Composer\Semver\VersionParser->normalize('3.10.0-dev1')
```