### PR TITLE
Fix PHP 8.2 'Creation of dynamic property' warning

### DIFF
--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -13,6 +13,7 @@ use WP_Error;
 
 abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
+	protected $fetcher;
 	protected $item_type;
 	protected $obj_fields;
 


### PR DESCRIPTION
Fixes #358 