### PR TITLE
Default to false when the "network" flag is omitted in the activate command

### DIFF
--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -62,6 +62,7 @@ Feature: Activate WordPress plugins
       Plugin 'user-switching' activated.
       """
 
+  @require-php-7
   Scenario: Activating a plugin with no network wide option passes down correct types
     Given a wp-content/plugins/example-plugin.php file:
       """
@@ -82,6 +83,7 @@ Feature: Activate WordPress plugins
       Plugin 'example-plugin' activated.
       Success: Activated 1 of 1 plugins.
       """
+      And STDERR should be empty
 
   Scenario: Not giving a slug on activate should throw an error unless --all given
     When I try `wp plugin activate`

--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -62,6 +62,27 @@ Feature: Activate WordPress plugins
       Plugin 'user-switching' activated.
       """
 
+  Scenario: Activating a plugin with no network wide option passes down correct types
+    Given a wp-content/plugins/example-plugin.php file:
+      """
+      <?php
+      // Plugin Name: Example Plugin
+
+      function example_plugin_activate( bool $network_wide = false ) {
+        // Doesn't matter what we do here, we just need a function definition to check the type
+        return;
+      }
+
+      register_activation_hook( __FILE__, 'example_plugin_activate' );
+      """
+
+    When I run `wp plugin activate example-plugin`
+    Then STDOUT should be:
+      """
+      Plugin 'example-plugin' activated.
+      Success: Activated 1 of 1 plugins.
+      """
+
   Scenario: Not giving a slug on activate should throw an error unless --all given
     When I try `wp plugin activate`
     Then the return code should be 1

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -310,7 +310,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     Success: Network activated 1 of 1 plugins.
 	 */
 	public function activate( $args, $assoc_args = array() ) {
-		$network_wide = Utils\get_flag_value( $assoc_args, 'network' );
+		$network_wide = Utils\get_flag_value( $assoc_args, 'network', false );
 		$all          = Utils\get_flag_value( $assoc_args, 'all', false );
 		$all_exclude  = Utils\get_flag_value( $assoc_args, 'exclude' );
 


### PR DESCRIPTION
Fixes #348

For the `activate` command, we're defaulting the `$network_wide` option to  `NULL` if the `--network` flag is omitted. This causes type errors further down in the code, as shown in issue #348.

I thought about doing the same for the `deactivate` command as well, but for deactivation, passing `null` is probably what we should keep since [it has its own meaning](https://github.com/WordPress/WordPress/blob/dbf0e1bf9e4b5632faff61d87ed5d0ed45a8e2bd/wp-admin/includes/plugin.php#L742) in the WordPress' `deactivate_plugins` function. 