### PR TITLE
check if plugin_update_info->new_version is_string to not fail with php version_compare

### DIFF
--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -727,8 +727,10 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				// Get info for all plugins that don't have an update.
 				$plugin_update_info = isset( $all_update_info->no_update[ $file ] ) ? $all_update_info->no_update[ $file ] : null;
 
-				// Compare version and update information in plugin list.
-				if ( null !== $plugin_update_info && version_compare( $details['Version'], $plugin_update_info->new_version, '>' ) ) {
+				// Compare version and update information in plugin list if possible
+				if (!is_string($plugin_update_info->new_version)) {
+					$items[ $file ]['update'] = static::INVALID_REMOTE_PLUGIN_VERSION;
+				} else if ( null !== $plugin_update_info && version_compare( $details['Version'], $plugin_update_info->new_version, '>' ) ) {
 					$items[ $file ]['update'] = static::INVALID_VERSION_MESSAGE;
 				}
 			}

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -728,10 +728,12 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				$plugin_update_info = isset( $all_update_info->no_update[ $file ] ) ? $all_update_info->no_update[ $file ] : null;
 
 				// Compare version and update information in plugin list if possible
-				if (!is_string($plugin_update_info->new_version)) {
-					$items[ $file ]['update'] = static::INVALID_REMOTE_PLUGIN_VERSION;
-				} else if ( null !== $plugin_update_info && version_compare( $details['Version'], $plugin_update_info->new_version, '>' ) ) {
-					$items[ $file ]['update'] = static::INVALID_VERSION_MESSAGE;
+				if (isset($plugin_update_info->new_version)) {
+					if (!is_string($plugin_update_info->new_version)) {
+						$items[$file]['update'] = static::INVALID_REMOTE_PLUGIN_VERSION;
+					} else if (version_compare($details['Version'], $plugin_update_info->new_version, '>')) {
+						$items[$file]['update'] = static::INVALID_VERSION_MESSAGE;
+					}
 				}
 			}
 		}

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -25,6 +25,8 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	// Invalid version message.
 	const INVALID_VERSION_MESSAGE = 'version higher than expected';
 
+	const INVALID_REMOTE_PLUGIN_VERSION = 'remote plugin version not a string, no update info available';
+
 	public function __construct() {
 
 		// Do not automatically check translations updates after updating plugins/themes.


### PR DESCRIPTION
if update version is not valid you'll get either warning or fatal error, so I'll add is_string to check remote version info to be valid string 

* php versions < 8 you'll see a warning on execution of "wp plugin list"
```
PHP Warning:  version_compare() expects parameter 2 to be string, array given in phar:///.../wp-cli.phar/vendor/wp-cli/extension-command/src/Plugin_Command.php on line 731
```

* php versions >= 8 you'll get fatal error and no further information:
```
thrown in phar:///usr/bin/wp/vendor/wp-cli/extension-command/src/Plugin_Command.php on line 731
Fatal error: Uncaught TypeError: version_compare(): Argument #2 ($version2) must be of type string, array given in phar:///usr/bin/wp/vendor/wp-cli/extension-command/src/Plugin_Command.php:731
Stack trace:
#0 phar:///usr/bin/wp/vendor/wp-cli/extension-command/src/Plugin_Command.php(731): version_compare()
#1 phar:///usr/bin/wp/vendor/wp-cli/extension-command/src/Plugin_Command.php(229): Plugin_Command->get_item_list()
#2 phar:///usr/bin/wp/vendor/wp-cli/extension-command/src/WP_CLI/CommandWithUpgrade.php(502): Plugin_Command->get_all_items()
#3 phar:///usr/bin/wp/vendor/wp-cli/extension-command/src/Plugin_Command.php(1212): WP_CLI\CommandWithUpgrade->_list()
#4 [internal function]: Plugin_Command->list_()
...
```

so I propose this small workaround which should avoid failing with fatal error in case there is no real version information of a plugin