### PR TITLE
Add optional 'author' field to `wp plugin list`

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -311,6 +311,11 @@ Feature: Manage WordPress plugins
       | name       | status   | file                |
       | akismet    | active   | akismet/akismet.php |
 
+    When I run `wp plugin list --status=active --fields=name,author`
+    Then STDOUT should be a table containing rows:
+      | name      | author                      |
+      | akismet   | Automattic - Anti Spam Team |
+
   Scenario: List plugin by multiple statuses
     Given a WP multisite install
     And a wp-content/plugins/network-only.php file:

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -311,10 +311,11 @@ Feature: Manage WordPress plugins
       | name       | status   | file                |
       | akismet    | active   | akismet/akismet.php |
 
-    When I run `wp plugin list --status=active --fields=name,author`
-    Then STDOUT should be a table containing rows:
-      | name      | author                      |
-      | akismet   | Automattic - Anti Spam Team |
+    When I run `wp plugin list --status=active --field=author`
+    Then STDOUT should contain:
+      """
+      Automattic
+      """
 
   Scenario: List plugin by multiple statuses
     Given a WP multisite install

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -274,6 +274,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'update_id'      => '',
 				'file'           => $name,
 				'auto_update'    => false,
+				'author'         => $item_data['Author'],
 			];
 		}
 
@@ -720,6 +721,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'description'    => wordwrap( $details['Description'] ),
 				'file'           => $file,
 				'auto_update'    => in_array( $file, $auto_updates, true ),
+				'author'         => $details['Author'],
 			];
 
 			if ( null === $update_info ) {
@@ -1184,6 +1186,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * * description
 	 * * file
 	 * * auto_update
+	 * * author
 	 *
 	 * ## EXAMPLES
 	 *


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

This PR addresses the issue https://github.com/wp-cli/extension-command/issues/368. It should now be possible to pass the `author` field when specifying `--fields` or `--field` to `plugin list`.

Related https://github.com/wp-cli/wp-cli/issues/5832