### PR TITLE
Apply check_package() on bulk_upgrade

### DIFF
--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -436,7 +436,10 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 				return $transient;
 			};
 			add_filter( 'site_transient_' . $this->upgrade_transient, $transient_filter, 999 );
+
+			add_filter( 'upgrader_source_selection', array( $upgrader, 'check_package' ) );
 			$result = $upgrader->bulk_upgrade( wp_list_pluck( $items_to_update, 'update_id' ) );
+			remove_filter( 'upgrader_source_selection', array( $upgrader, 'check_package' ) );
 			remove_filter( 'site_transient_' . $this->upgrade_transient, $transient_filter, 999 );
 		}
 

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -436,7 +436,6 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 				return $transient;
 			};
 			add_filter( 'site_transient_' . $this->upgrade_transient, $transient_filter, 999 );
-
 			add_filter( 'upgrader_source_selection', array( $upgrader, 'check_package' ) );
 			$result = $upgrader->bulk_upgrade( wp_list_pluck( $items_to_update, 'update_id' ) );
 			remove_filter( 'upgrader_source_selection', array( $upgrader, 'check_package' ) );


### PR DESCRIPTION
I'm opening this as a Draft PR for reference, as these changes should resolve #357

However, I believe this is a WordPress core issue and have opened [Trac Ticket 59198](https://core.trac.wordpress.org/ticket/59198) in the hopes it can be resolved there.

--------------------

Add the check_package() function to the
"upgrader_source_selection" filter hook.

This applies the check for PHP minimum version number
before "bulk" updating a plugin.

Note: A "bulk" upgrade occurs even when a single plugin is updated,
e.g. the following uses the "bulk" upgrade code

wp plugin update gutenberg

Resolves #357
