### PR TITLE
Add `update_version` to the default fields for `plugin` and `theme` commands

### DIFF
--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -13,8 +13,8 @@ Feature: Update WordPress plugins
 
     When I run `wp plugin list`
     Then STDOUT should be a table containing rows:
-      | name               | status   | update    | version |
-      | wordpress-importer | inactive | available | 0.5     |
+      | name               | status   | update    | version | update_version   |
+      | wordpress-importer | inactive | available | 0.5     | {UPDATE_VERSION} |
 
     When I try `wp plugin update akismet --version=0.5.3`
     Then STDERR should be:
@@ -25,16 +25,16 @@ Feature: Update WordPress plugins
 
     When I run `wp plugin list`
     Then STDOUT should be a table containing rows:
-      | name               | status   | update    | version |
-      | wordpress-importer | inactive | available | 0.5     |
+      | name               | status   | update    | version | update_version   |
+      | wordpress-importer | inactive | available | 0.5     | {UPDATE_VERSION} |
 
     When I run `wp plugin update wordpress-importer`
     Then STDOUT should not be empty
 
     When I run `wp plugin list`
     Then STDOUT should be a table containing rows:
-      | name               | status   | update    | version           |
-      | wordpress-importer | inactive | none      | {UPDATE_VERSION}  |
+      | name               | status   | update    | version           | update_version   |
+      | wordpress-importer | inactive | none      | {UPDATE_VERSION}  |                  |
 
   Scenario: Error when both --minor and --patch are provided
     Given a WP install

--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -33,8 +33,8 @@ Feature: Update WordPress plugins
 
     When I run `wp plugin list`
     Then STDOUT should be a table containing rows:
-      | name               | status   | update    | version           | update_version   |
-      | wordpress-importer | inactive | none      | {UPDATE_VERSION}  |                  |
+      | name               | status   | update    | version           | update_version |
+      | wordpress-importer | inactive | none      | {UPDATE_VERSION}  |                |
 
   Scenario: Error when both --minor and --patch are provided
     Given a WP install

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -63,8 +63,8 @@ Feature: Manage WordPress plugins
 
     When I run `wp plugin list`
     Then STDOUT should be a table containing rows:
-      | name       | status | update | version |
-      | Zombieland | active | none   | 0.1.0   |
+      | name       | status | update | version | update_version |
+      | Zombieland | active | none   | 0.1.0   |                |
 
     When I try `wp plugin uninstall Zombieland`
     Then STDERR should be:
@@ -131,8 +131,8 @@ Feature: Manage WordPress plugins
 
     When I run `wp plugin list`
     Then STDOUT should be a table containing rows:
-      | name               | status   | update    | version |
-      | wordpress-importer | active   | available | 0.5     |
+      | name               | status   | update    | version | update_version   |
+      | wordpress-importer | active | available | 0.5     | {UPDATE_VERSION} |
 
     When I try `wp plugin update`
     Then STDERR should be:
@@ -648,11 +648,14 @@ Feature: Manage WordPress plugins
 
     When I run `wp plugin list --name=hello-dolly  --field=version`
     And save STDOUT as {PLUGIN_VERSION}
+    
+    When I run `wp plugin list --name=hello-dolly  --field=update_version`
+    And save STDOUT as {UPDATE_VERSION}
 
     When I run `wp plugin list`
     Then STDOUT should be a table containing rows:
-      | name               | status   | update                       | version          |
-      | hello-dolly        | inactive | version higher than expected | {PLUGIN_VERSION} |
+      | name               | status   | update                       | version          | update_version   |
+      | hello-dolly        | inactive | version higher than expected | {PLUGIN_VERSION} | {UPDATE_VERSION} |
 
     When I try `wp plugin update --all`
     Then STDERR should be:

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -131,8 +131,8 @@ Feature: Manage WordPress plugins
 
     When I run `wp plugin list`
     Then STDOUT should be a table containing rows:
-      | name               | status   | update    | version | update_version   |
-      | wordpress-importer | active | available | 0.5     | {UPDATE_VERSION} |
+      | name               | status   | update      | version | update_version   |
+      | wordpress-importer | active   | available   | 0.5     | {UPDATE_VERSION} |
 
     When I try `wp plugin update`
     Then STDERR should be:

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -131,8 +131,8 @@ Feature: Manage WordPress plugins
 
     When I run `wp plugin list`
     Then STDOUT should be a table containing rows:
-      | name               | status   | update      | version | update_version   |
-      | wordpress-importer | active   | available   | 0.5     | {UPDATE_VERSION} |
+      | name               | status   | update    | version | update_version   |
+      | wordpress-importer | active   | available | 0.5     | {UPDATE_VERSION} |
 
     When I try `wp plugin update`
     Then STDERR should be:

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -84,7 +84,7 @@ Feature: Manage WordPress themes
     When I run `wp theme list`
     Then STDOUT should be a table containing rows:
       | name  | status   | update    | version   | update_version   |
-      | p2    | active | available | 1.4.2     | {UPDATE_VERSION} |
+      | p2    | inactive | available | 1.4.2     | {UPDATE_VERSION} |
 
     When I run `wp theme activate p2`
     Then STDOUT should not be empty
@@ -102,7 +102,7 @@ Feature: Manage WordPress themes
     When I run `wp theme list`
     Then STDOUT should be a table containing rows:
       | name  | status   | update    | version   | update_version |
-      | p2    | inactive | available | 1.4.1     | {UPDATE_VERSION} |
+      | p2    | active | available | 1.4.1     | {UPDATE_VERSION} |
 
     When I try `wp theme update`
     Then STDERR should be:

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -84,7 +84,7 @@ Feature: Manage WordPress themes
     When I run `wp theme list`
     Then STDOUT should be a table containing rows:
       | name  | status   | update    | version   | update_version   |
-      | p2    | inactive | available | 1.4.2     | {UPDATE_VERSION} |
+      | p2    | active | available | 1.4.2     | {UPDATE_VERSION} |
 
     When I run `wp theme activate p2`
     Then STDOUT should not be empty

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -77,10 +77,14 @@ Feature: Manage WordPress themes
     When I run `wp theme install p2 --version=1.4.2`
     Then STDOUT should not be empty
 
+    When I run `wp theme list --name=p2 --field=update_version`
+    Then STDOUT should not be empty
+    And save STDOUT as {UPDATE_VERSION}
+
     When I run `wp theme list`
     Then STDOUT should be a table containing rows:
-      | name  | status   | update    | version   |
-      | p2    | inactive | available | 1.4.2     |
+      | name  | status   | update    | version   | update_version   |
+      | p2    | inactive | available | 1.4.2     | {UPDATE_VERSION} |
 
     When I run `wp theme activate p2`
     Then STDOUT should not be empty
@@ -97,8 +101,8 @@ Feature: Manage WordPress themes
 
     When I run `wp theme list`
     Then STDOUT should be a table containing rows:
-      | name  | status   | update    | version   |
-      | p2    | active   | available | 1.4.1     |
+      | name  | status   | update    | version   | update_version |
+      | p2    | inactive | available | 1.4.1     | {UPDATE_VERSION} |
 
     When I try `wp theme update`
     Then STDERR should be:

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -101,8 +101,8 @@ Feature: Manage WordPress themes
 
     When I run `wp theme list`
     Then STDOUT should be a table containing rows:
-      | name  | status   | update    | version   | update_version |
-      | p2    | active | available | 1.4.1     | {UPDATE_VERSION} |
+      | name  | status   | update    | version   | update_version   |
+      | p2    | active   | available | 1.4.1     | {UPDATE_VERSION} |
 
     When I try `wp theme update`
     Then STDERR should be:

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -51,10 +51,14 @@ Feature: Manage WordPress themes and plugins
        "<item_title>"
        """
 
+    When I run `wp <type> list --name=<item> --field=update_version`
+    Then STDOUT should not be empty
+    And save STDOUT as {UPDATE_VERSION}
+
     When I run `wp <type> list`
     Then STDOUT should be a table containing rows:
-      | name   | status   | update    | version   |
-      | <item> | inactive | available | <version> |
+      | name   | status   | update    | version   | update_version   |
+      | <item> | inactive | available | <version> | {UPDATE_VERSION} |
 
     When I run `wp <type> list --field=name`
     Then STDOUT should contain:

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1193,7 +1193,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *
 	 *     # List active plugins on the site.
 	 *     $ wp plugin list --status=active --format=json
-	 *     [{"name":"dynamic-hostname","status":"active","update":"none","version":"0.4.2","update_version": null},{"name":"tinymce-templates","status":"active","update":"none","version":"4.4.3","update_version": null},{"name":"wp-multibyte-patch","status":"active","update":"none","version":"2.4","update_version": null},{"name":"wp-total-hacks","status":"active","update":"none","version":"2.0.1","update_version": null}]
+	 *     [{"name":"dynamic-hostname","status":"active","update":"none","version":"0.4.2","update_version": ""},{"name":"tinymce-templates","status":"active","update":"none","version":"4.4.3","update_version": ""},{"name":"wp-multibyte-patch","status":"active","update":"none","version":"2.4","update_version": ""},{"name":"wp-total-hacks","status":"active","update":"none","version":"2.0.1","update_version": ""}]
 	 *
 	 *     # List plugins on each site in a network.
 	 *     $ wp site list --field=url | xargs -I % wp plugin list --url=%

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1176,10 +1176,10 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * * status
 	 * * update
 	 * * version
+	 * * update_version
 	 *
 	 * These fields are optionally available:
 	 *
-	 * * update_version
 	 * * update_package
 	 * * update_id
 	 * * title
@@ -1192,22 +1192,22 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *
 	 *     # List active plugins on the site.
 	 *     $ wp plugin list --status=active --format=json
-	 *     [{"name":"dynamic-hostname","status":"active","update":"none","version":"0.4.2"},{"name":"tinymce-templates","status":"active","update":"none","version":"4.4.3"},{"name":"wp-multibyte-patch","status":"active","update":"none","version":"2.4"},{"name":"wp-total-hacks","status":"active","update":"none","version":"2.0.1"}]
+	 *     [{"name":"dynamic-hostname","status":"active","update":"none","version":"0.4.2","update_version": null},{"name":"tinymce-templates","status":"active","update":"none","version":"4.4.3","update_version": null},{"name":"wp-multibyte-patch","status":"active","update":"none","version":"2.4","update_version": null},{"name":"wp-total-hacks","status":"active","update":"none","version":"2.0.1","update_version": null}]
 	 *
 	 *     # List plugins on each site in a network.
 	 *     $ wp site list --field=url | xargs -I % wp plugin list --url=%
-	 *     +---------+----------------+--------+---------+
-	 *     | name    | status         | update | version |
-	 *     +---------+----------------+--------+---------+
-	 *     | akismet | active-network | none   | 3.1.11  |
-	 *     | hello   | inactive       | none   | 1.6     |
-	 *     +---------+----------------+--------+---------+
-	 *     +---------+----------------+--------+---------+
-	 *     | name    | status         | update | version |
-	 *     +---------+----------------+--------+---------+
-	 *     | akismet | active-network | none   | 3.1.11  |
-	 *     | hello   | inactive       | none   | 1.6     |
-	 *     +---------+----------------+--------+---------+
+	 *     +---------+----------------+--------+---------+----------------+
+	 *     | name    | status         | update | version | update_version |
+	 *     +---------+----------------+--------+---------+----------------+
+	 *     | akismet | active-network | none   | 3.1.11  |                |
+	 *     | hello   | inactive       | none   | 1.6     | 1.7.2          |
+	 *     +---------+----------------+--------+---------+----------------+
+	 *     +---------+----------------+--------+---------+----------------+
+	 *     | name    | status         | update | version | update_version |
+	 *     +---------+----------------+--------+---------+----------------+
+	 *     | akismet | active-network | none   | 3.1.11  |                |
+	 *     | hello   | inactive       | none   | 1.6     | 1.7.2          |
+	 *     +---------+----------------+--------+---------+----------------+
 	 *
 	 * @subcommand list
 	 */

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -52,6 +52,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		'status',
 		'update',
 		'version',
+		'update_version',
 	);
 
 	/**

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -49,7 +49,7 @@ class Theme_Command extends CommandWithUpgrade {
 	protected $upgrade_refresh   = 'wp_update_themes';
 	protected $upgrade_transient = 'update_themes';
 
-	protected $obj_fields = [ 'name', 'status', 'update', 'version' ];
+	protected $obj_fields = [ 'name', 'status', 'update', 'version', 'update_version' ];
 
 	public function __construct() {
 		if ( is_multisite() ) {

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -846,10 +846,10 @@ class Theme_Command extends CommandWithUpgrade {
 	 * * status
 	 * * update
 	 * * version
+	 * * update_version
 	 *
 	 * These fields are optionally available:
 	 *
-	 * * update_version
 	 * * update_package
 	 * * update_id
 	 * * title
@@ -860,9 +860,9 @@ class Theme_Command extends CommandWithUpgrade {
 	 *
 	 *     # List themes
 	 *     $ wp theme list --status=inactive --format=csv
-	 *     name,status,update,version
-	 *     twentyfourteen,inactive,none,1.7
-	 *     twentysixteen,inactive,available,1.1
+	 *     name,status,update,version,update_version
+	 *     twentyfourteen,inactive,none,1.7,
+	 *     twentysixteen,inactive,available,1.1,
 	 *
 	 * @subcommand list
 	 */

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -511,6 +511,10 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 				$item['version'] = '';
 			}
 
+			if ( empty( $item['update_version'] ) ) {
+				$item['update_version'] = '';
+			}
+
 			foreach ( $item as $field => &$value ) {
 				if ( 'update' === $field ) {
 					if ( true === $value ) {


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
- Related:
  - https://github.com/wp-cli/wp-cli/issues/5859
  - https://github.com/wp-cli/extension-command/issues/198

## Description

I'm adding the field `update_version` as a default field for `plugin` and `theme` commands. If no `update_version` is available we return an empty string following the same pattern as `version` itself.

Now `wp plugin list` and `wp theme list` display a table similar to:
```
+------------+----------+--------+---------+----------------+-------------+
| name       | status   | update | version | update_version | auto_update |
+------------+----------+--------+---------+----------------+-------------+
| akismet    | inactive | none   | 5.3     |                | off         |
| hello      | inactive | none   | 1.7.2   |                | off         |
| Zombieland | inactive | none   | 0.1.0   |                | off         |
| no-mail    | must-use | none   |         |                | off         |
| polyfills  | must-use | none   |         |                | off         |
+------------+----------+--------+---------+----------------+-------------+
```

```
+-------------------+----------+--------+---------+----------------+-------------+
| name              | status   | update | version | update_version | auto_update |
+-------------------+----------+--------+---------+----------------+-------------+
| twentytwentyfour  | active   | none   | 1.0     |                | off         |
| twentytwentythree | inactive | none   | 1.3     |                | off         |
| twentytwentytwo   | inactive | none   | 1.6     |                | off         |
+-------------------+----------+--------+---------+----------------+-------------+
```



## Testing instructions

1. Run `composer behat -- features/plugin-update.feature`
2. Run `composer behat -- features/plugin.feature`
3. Run `composer behat -- features/upgradables.feature`
4. Run `composer behat -- features/theme.feature`
5. Observe the tests pass
