### PR TITLE
Add support GitHub releases/latest on installation

### DIFF
--- a/features/plugin-install-github-latest.feature
+++ b/features/plugin-install-github-latest.feature
@@ -1,0 +1,15 @@
+Feature: Install WordPress plugins
+
+  Scenario: Verify that providing a plugin releases/latest GitHub URL will get the latest ZIP
+    Given a WP install
+    When I run `wp plugin install https://github.com/danielbachhuber/one-time-login/releases/latest`
+    Then STDOUT should contain:
+      """
+      Latest release resolved to Version 0.4.0
+      Downloading installation package from
+      """
+    And STDOUT should contain:
+      """
+      Plugin installed successfully.
+      Success: Installed 1 of 1 plugins.
+      """

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -160,19 +160,23 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 			$github_parser = new ParseGithubUrlInput();
 
-			if ( $is_remote && $github_repo = $github_parser->get_github_repo_from_url( $slug ) ) {
-				$version = $github_parser->get_the_latest_github_version( $github_repo );
+			if ( $is_remote ) {
+				$github_repo = $github_parser->get_github_repo_from_url( $slug );
 
-				if ( is_wp_error( $version ) ) {
-					WP_CLI::error( $version->get_error_message() );
+				if ( $github_repo ) {
+					$version = $github_parser->get_the_latest_github_version( $github_repo );
+
+					if ( is_wp_error( $version ) ) {
+						WP_CLI::error( $version->get_error_message() );
+					}
+
+					/**
+					 * Sets the $slug that will trigger the installation based on a zip file.
+					 */
+					$slug = $version['url'];
+
+					WP_CLI::log( 'Latest release resolved to ' . $version['name'] );
 				}
-
-				/**
-				 * Sets the $slug that will trigger the installation based on a zip file.
-				 */
-				$slug = $version['url'];
-
-				WP_CLI::log( 'Latest release resolved to ' . $version['name'] );
 			}
 
 			// Check if a URL to a remote or local zip has been specified.

--- a/src/WP_CLI/ParseGithubUrlInput.php
+++ b/src/WP_CLI/ParseGithubUrlInput.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace WP_CLI;
+
+final class ParseGithubUrlInput {
+
+	/**
+	 * The GitHub Releases public api endpoint.
+	 *
+	 * @var string
+	 */
+	private $github_releases_api_endpoint = 'https://api.github.com/repos/%s/releases';
+
+	/**
+	 * The GitHub latest release url format.
+	 *
+	 * @var string
+	 */
+	private $github_latest_release_url = '/^https:\/\/github\.com\/(.*)\/releases\/latest\/?$/';
+
+	/**
+	 * Get the latest package version based on a given repo slug.
+	 *
+	 * @param string $repo_slug
+	 *
+	 * @return array{ name: string, url: string }|\WP_Error
+	 */
+	public function get_the_latest_github_version( $repo_slug ) {
+		$api_url = sprintf( $this->github_releases_api_endpoint, $repo_slug );
+
+		$response = \wp_remote_get( $api_url );
+
+		if ( \is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body         = \wp_remote_retrieve_body( $response );
+		$decoded_body = json_decode( $body );
+
+		if ( wp_remote_retrieve_response_code( $response ) === \WP_Http::FORBIDDEN ) {
+			return new \WP_Error( \WP_Http::FORBIDDEN, $decoded_body->message . PHP_EOL . $decoded_body->documentation_url );
+		}
+
+		if ( null === $decoded_body ) {
+			return new \WP_Error( 500, 'Empty response received from GitHub.com API' );
+		}
+
+		if ( ! isset( $decoded_body[0] ) ) {
+			return new \WP_Error( '400', 'The given Github repository does not have any releases' );
+		}
+
+		$latest_release = $decoded_body[0];
+
+		return [ 'name' => $latest_release->name, 'url' => $this->get_asset_url_from_release( $latest_release ) ];
+	}
+
+	/**
+	 * Get the asset URL from the release array. When the asset is not present, we fallback to the zipball_url (source code) property.
+	 *
+	 * @param array $release
+	 *
+	 * @return string|null
+	 */
+	private function get_asset_url_from_release( $release ) {
+		if ( isset( $release->assets[0]->browser_download_url ) ) {
+			return $release->assets[0]->browser_download_url;
+		}
+
+		if ( isset( $release->zipball_url ) ) {
+			return $release->zipball_url;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the GitHub repo from the URL.
+	 *
+	 * @param string $url
+	 *
+	 * @return string|null
+	 */
+	public function get_github_repo_from_url( $url ) {
+		preg_match( $this->github_latest_release_url, $url, $matches );
+
+		return isset( $matches[1] ) ? $matches[1] : null;
+	}
+}


### PR DESCRIPTION
Related to https://github.com/wp-cli/extension-command/issues/91

This PR adds support for installing plugins and themes from GitHub using the `release/latest` URLs.

In order to get the latest release assets, I'm proposing to use the GitHub public API to extract the latest version of the plugin/theme from GH releases. If there's no asset defined, we will fall back to the source code zip file.

~~While the implementation works right now, I haven't added support for GitHub's API request limits. Currently, after 60 requests per hour, the user is required to use an access token in order to make an API request. However, this PR doesn't expose a way to pass that token to the request.~~

**UPDATE**:
I've introduced a new environment variable called _GITHUB_TOKEN_.