### PR TITLE
Switch tests to use `site-secrets` instead of `user-switching`

### DIFF
--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -35,7 +35,7 @@ Feature: Activate WordPress plugins
     And the return code should be 1
 
   Scenario: Activate all when one plugin is hidden by "all_plugins" filter
-    Given I run `wp plugin install user-switching`
+    Given I run `wp plugin install site-secrets`
     And a wp-content/mu-plugins/hide-us-plugin.php file:
       """
       <?php
@@ -46,7 +46,7 @@ Feature: Activate WordPress plugins
        */
 
        add_filter( 'all_plugins', function( $all_plugins ) {
-          unset( $all_plugins['user-switching/user-switching.php'] );
+          unset( $all_plugins['site-secrets/site-secrets.php'] );
           return $all_plugins;
        } );
        """
@@ -59,7 +59,7 @@ Feature: Activate WordPress plugins
       """
     And STDOUT should not contain:
       """
-      Plugin 'user-switching' activated.
+      Plugin 'site-secrets' activated.
       """
 
   @require-php-7

--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -113,14 +113,14 @@ Feature: Install WordPress plugins
   Scenario: Return code is 1 when one or more plugin installations fail
     Given a WP install
 
-    When I try `wp plugin install user-switching user-switching-not-a-plugin`
+    When I try `wp plugin install site-secrets site-secrets-not-a-plugin`
     Then STDERR should contain:
       """
       Warning:
       """
     And STDERR should contain:
       """
-      user-switching-not-a-plugin
+      site-secrets-not-a-plugin
       """
     And STDERR should contain:
       """
@@ -128,7 +128,7 @@ Feature: Install WordPress plugins
       """
     And STDOUT should contain:
       """
-      Installing User Switching
+      Installing Site Secrets
       """
     And STDOUT should contain:
       """
@@ -136,25 +136,25 @@ Feature: Install WordPress plugins
       """
     And the return code should be 1
 
-    When I try `wp plugin install user-switching`
+    When I try `wp plugin install site-secrets`
     Then STDOUT should be:
       """
       Success: Plugin already installed.
       """
     And STDERR should be:
       """
-      Warning: user-switching: Plugin already installed.
+      Warning: site-secrets: Plugin already installed.
       """
     And the return code should be 0
 
-    When I try `wp plugin install user-switching-not-a-plugin`
+    When I try `wp plugin install site-secrets-not-a-plugin`
     Then STDERR should contain:
       """
       Warning:
       """
     And STDERR should contain:
       """
-      user-switching-not-a-plugin
+      site-secrets-not-a-plugin
       """
     And STDERR should contain:
       """
@@ -222,18 +222,18 @@ Feature: Install WordPress plugins
   Scenario: Verify installed plugin activation
     Given a WP install
 
-    When I run `wp plugin install user-switching`
+    When I run `wp plugin install site-secrets`
     Then STDOUT should not be empty
 
-    When I try `wp plugin install user-switching --activate`
+    When I try `wp plugin install site-secrets --activate`
     Then STDERR should contain:
     """
-    Warning: user-switching: Plugin already installed.
+    Warning: site-secrets: Plugin already installed.
     """
 
     And STDOUT should contain:
     """
-    Activating 'user-switching'...
-    Plugin 'user-switching' activated.
+    Activating 'site-secrets'...
+    Plugin 'site-secrets' activated.
     Success: Plugin already installed.
     """

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -580,7 +580,7 @@ Feature: Manage WordPress plugins
       """
       akismet
       jetpack
-      user-switching
+      site-secrets
       """
     And a wp-content/mu-plugins/hide-us-plugin.php file:
       """
@@ -592,7 +592,7 @@ Feature: Manage WordPress plugins
        */
 
        add_filter( 'all_plugins', function( $all_plugins ) {
-          unset( $all_plugins['user-switching/user-switching.php'] );
+          unset( $all_plugins['site-secrets/site-secrets.php'] );
           return $all_plugins;
        } );
        """
@@ -600,7 +600,7 @@ Feature: Manage WordPress plugins
     When I run `wp plugin list --fields=name`
     Then STDOUT should not contain:
       """
-      user-switching
+      site-secrets
       """
 
   Scenario: Show dropins plugin list

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -585,8 +585,8 @@ Feature: Manage WordPress plugins
       """
       <?php
       /**
-       * Plugin Name: Hide User Switchign on Production
-       * Description: Hides the User Switching plugin on production sites
+       * Plugin Name: Hide Site Secrets on Production
+       * Description: Hides the Site Secrets plugin on production sites
        * Author: WP-CLI tests
        */
 

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -579,7 +579,6 @@ Feature: Manage WordPress plugins
     And these installed and active plugins:
       """
       akismet
-      jetpack
       site-secrets
       """
     And a wp-content/mu-plugins/hide-us-plugin.php file:

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -170,7 +170,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 						// Don't attempt to rename ZIPs uploaded to the releases page or coming from a raw source.
 						&& ! preg_match( '#github\.com/[^/]+/[^/]+/(?:releases/download|raw)/#', $slug ) ) {
 
-					$filter = function ( $source, $remote_source, $upgrader ) use ( $slug ) {
+					$filter = function ( $source ) use ( $slug ) {
 
 						$slug_dir = Utils\basename( $this->parse_url_host_component( $slug, PHP_URL_PATH ), '.zip' );
 
@@ -193,7 +193,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 						return new WP_Error( 'wpcli_install_github', "Couldn't move Github-based project to appropriate directory." );
 					};
-					add_filter( 'upgrader_source_selection', $filter, 10, 3 );
+					add_filter( 'upgrader_source_selection', $filter, 10 );
 				}
 
 				if ( $file_upgrader->install( $slug ) ) {


### PR DESCRIPTION
User Switching increased its minimum supported PHP version, and started breaking our tests. Time to use Daniel's plugin instead! Sorry John.
