### PR TITLE
Fix  message on error in plugin activation

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -245,10 +245,6 @@ Feature: Manage WordPress plugins
       """
       Warning: Plugin 'akismet' is already active.
       """
-    And STDOUT should be:
-      """
-      Success: Plugin already activated.
-      """
     And the return code should be 0
 
     When I run `wp plugin activate akismet --network`
@@ -262,10 +258,6 @@ Feature: Manage WordPress plugins
     Then STDERR should be:
       """
       Warning: Plugin 'akismet' is already network active.
-      """
-    And STDOUT should be:
-      """
-      Success: Plugin already network activated.
       """
     And the return code should be 0
 
@@ -649,7 +641,7 @@ Feature: Manage WordPress plugins
 
     When I run `wp plugin list --name=hello-dolly  --field=version`
     And save STDOUT as {PLUGIN_VERSION}
-    
+
     When I run `wp plugin list --name=hello-dolly  --field=update_version`
     And save STDOUT as {UPDATE_VERSION}
 

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -374,7 +374,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			}
 		}
 
-		if ( ! $this->chained_command ) {
+		if ( ! $this->chained_command && ( $successes || $errors ) ) {
 			$verb = $network_wide ? 'network activate' : 'activate';
 			Utils\report_batch_operation_results( 'plugin', $verb, count( $args ), $successes, $errors );
 		}


### PR DESCRIPTION
```
wp plugin activate hello.php
```

When some plugin generates error while activation, output was shown like this.
```
Warning: Failed to activate plugin. Current PHP version (8.1.16) does not meet minimum requirements for Hello Dolly. The plugin requires PHP 9.0..
Success: Plugin already activated.
```

In this PR, above issue is fixed.

Output of `wp plugin activate hello.php`:

```
Warning: Failed to activate plugin. Current PHP version (7.4.33) does not meet minimum requirements for Hello Dolly. The plugin requires PHP 9.0..
Success: Activated 0 of 1 plugins (1 skipped).
```

Output of `wp plugin activate hello.php disable-gutenberg`:
```
Warning: Failed to activate plugin. Current PHP version (7.4.33) does not meet minimum requirements for Hello Dolly. The plugin requires PHP 9.0..
Plugin 'disable-gutenberg' activated.
Success: Activated 1 of 2 plugins (1 skipped).
```