### PR TITLE
Fix counting of errors when attempting activations

### DIFF
--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -148,3 +148,26 @@ Feature: Activate WordPress plugins
       Success:
       """
     And the return code should be 0
+
+  Scenario: Incompatible plugins cannot be activated
+    Given a WP installation
+    And a wp-content/plugins/incompatible-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Incompatible Plugin
+       * Requires PHP: 42.0
+       */
+      """
+    And I run `wp cli info | grep "PHP version" | awk '{print $3}'`
+    And save STDOUT as {PHP_VERSION}
+
+    When I try `wp plugin activate incompatible-plugin`
+    Then STDERR should contain:
+      """
+      Failed to activate plugin. Current PHP version ({PHP_VERSION}) does not meet minimum requirements for Incompatible Plugin. The plugin requires PHP 42.0.
+      """
+    And STDOUT should not contain:
+      """
+      Success:
+      """

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -368,6 +368,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				$message = wp_strip_all_tags( $message );
 				$message = str_replace( 'Error: ', '', $message );
 				WP_CLI::warning( "Failed to activate plugin. {$message}" );
+				++$errors;
 			} else {
 				$this->active_output( $plugin->name, $plugin->file, $network_wide, 'activate' );
 				++$successes;


### PR DESCRIPTION
Fixes #396

Errors during plugin activation were properly detected, but not actually counted, therefore printing an incorrect `Success: ...` message during the batch operation processing.

By properly counting errors as they are detected, the batch processing will correctly use the success or failure message that is appropriate.