### PR TITLE
Show additional plugin headers values in `wp plugin get <plugin>` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,28 @@ wp plugin get <plugin> [--field=<field>] [--fields=<fields>] [--format=<format>]
 		  - yaml
 		---
 
+**AVAILABLE FIELDS**
+
+These fields will be displayed by default for the plugin:
+
+* name
+* title
+* author
+* version
+* description
+* status
+
+These fields are optionally available:
+
+* requires_wp
+* requires_php
+* requires_plugins
+
 **EXAMPLES**
 
+    # Get plugin details.
     $ wp plugin get bbpress --format=json
-    {"name":"bbpress","title":"bbPress","author":"The bbPress Contributors","version":"2.6-alpha","description":"bbPress is forum software with a twist from the creators of WordPress.","status":"active"}
+    {"name":"bbpress","title":"bbPress","author":"The bbPress Contributors","version":"2.6.9","description":"bbPress is forum software with a twist from the creators of WordPress.","status":"active"}
 
 
 

--- a/features/plugin-get.feature
+++ b/features/plugin-get.feature
@@ -1,0 +1,47 @@
+Feature: Get WordPress plugin
+
+  Scenario: Get plugin info
+    Given a WP install
+    And a wp-content/plugins/foo.php file:
+      """
+      /**
+       * Plugin Name: Sample Plugin
+       * Description: Description for sample plugin.
+       * Requires at least: 6.0
+       * Requires PHP: 5.6
+       * Version: 1.0.0
+       * Author: John Doe
+       * Author URI: https://example.com/
+       * License: GPLv2 or later
+       * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+       * Text Domain: sample-plugin
+       */
+       """
+
+    When I run `wp plugin get foo --fields=name,author,version,status`
+    Then STDOUT should be a table containing rows:
+      | Field   | Value    |
+      | name    | foo      |
+      | author  | John Doe |
+      | version | 1.0.0    |
+      | status  | inactive |
+
+  @require-wp-6.5
+  Scenario: Get Requires Plugins header of plugin
+    Given a WP install
+    And a wp-content/plugins/foo.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo
+       * Description: Foo plugin
+       * Author: John Doe
+       * Requires Plugins: jetpack, woocommerce
+       */
+       """
+
+    When I run `wp plugin get foo --field=requires_plugins`
+    Then STDOUT should be:
+      """
+      jetpack, woocommerce
+      """

--- a/features/plugin-get.feature
+++ b/features/plugin-get.feature
@@ -26,6 +26,12 @@ Feature: Get WordPress plugin
       | version | 1.0.0    |
       | status  | inactive |
 
+    When I run `wp plugin get foo --format=json`
+    Then STDOUT should be:
+      """
+      {"name":"foo","title":"Sample Plugin","author":"John Doe","version":"1.0.0","description":"Description for sample plugin.","status":"inactive"}
+      """
+
   @require-wp-6.5
   Scenario: Get Requires Plugins header of plugin
     Given a WP install
@@ -45,3 +51,24 @@ Feature: Get WordPress plugin
       """
       jetpack, woocommerce
       """
+
+  @require-wp-5.3
+  Scenario: Get Requires PHP and Requires WP header of plugin
+    Given a WP install
+    And a wp-content/plugins/foo.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo
+       * Description: Foo plugin
+       * Author: John Doe
+       * Requires at least: 6.2
+       * Requires PHP: 7.4
+       */
+       """
+
+    When I run `wp plugin get foo --fields=requires_wp,requires_php`
+    Then STDOUT should be a table containing rows:
+      | Field        | Value |
+      | requires_wp  | 6.2   |
+      | requires_php | 7.4   |

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -947,27 +947,46 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     {"name":"bbpress","title":"bbPress","author":"The bbPress Contributors","version":"2.6-alpha","description":"bbPress is forum software with a twist from the creators of WordPress.","status":"active"}
 	 */
 	public function get( $args, $assoc_args ) {
+		$default_fields = array(
+			'name',
+			'title',
+			'author',
+			'version',
+			'description',
+			'status',
+		);
+
 		$plugin = $this->fetcher->get_check( $args[0] );
 		$file   = $plugin->file;
 
 		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $file, false, false );
 
 		$plugin_obj = (object) [
-			'name'        => Utils\get_plugin_name( $file ),
-			'title'       => $plugin_data['Name'],
-			'author'      => $plugin_data['Author'],
-			'version'     => $plugin_data['Version'],
-			'description' => wordwrap( $plugin_data['Description'] ),
-			'status'      => $this->get_status( $file ),
+			'name'             => Utils\get_plugin_name( $file ),
+			'title'            => $plugin_data['Name'],
+			'author'           => $plugin_data['Author'],
+			'version'          => $plugin_data['Version'],
+			'description'      => wordwrap( $plugin_data['Description'] ),
+			'status'           => $this->get_status( $file ),
+			'requires_wp'      => '',
+			'requires_php'     => '',
+			'requires_plugins' => '',
 		];
 
-		if ( isset( $plugin_data['RequiresPlugins'] ) && ! empty( $plugin_data['RequiresPlugins'] ) ) {
-			$plugin_obj->requires_plugins = $plugin_data['RequiresPlugins'];
+		$require_fields = [
+			'requires_wp'      => 'RequiresWP',
+			'requires_php'     => 'RequiresPHP',
+			'requires_plugins' => 'RequiresPlugins',
+		];
+
+		foreach ( $require_fields as $field_key => $data_key ) {
+			if ( isset( $plugin_data[ $data_key ] ) && ! empty( $plugin_data[ $data_key ] ) ) {
+				$plugin_obj->{$field_key} = $plugin_data[ $data_key ];
+			}
 		}
 
 		if ( empty( $assoc_args['fields'] ) ) {
-			$plugin_array         = get_object_vars( $plugin_obj );
-			$assoc_args['fields'] = array_keys( $plugin_array );
+			$assoc_args['fields'] = $default_fields;
 		}
 
 		$formatter = $this->get_formatter( $assoc_args );

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -961,6 +961,10 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			'status'      => $this->get_status( $file ),
 		];
 
+		if ( isset( $plugin_data['RequiresPlugins'] ) && ! empty( $plugin_data['RequiresPlugins'] ) ) {
+			$plugin_obj->requires_plugins = $plugin_data['RequiresPlugins'];
+		}
+
 		if ( empty( $assoc_args['fields'] ) ) {
 			$plugin_array         = get_object_vars( $plugin_obj );
 			$assoc_args['fields'] = array_keys( $plugin_array );

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -986,22 +986,10 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			'version'          => $plugin_data['Version'],
 			'description'      => wordwrap( $plugin_data['Description'] ),
 			'status'           => $this->get_status( $file ),
-			'requires_wp'      => '',
-			'requires_php'     => '',
-			'requires_plugins' => '',
+			'requires_wp'      => ! empty( $plugin_data['RequiresWP'] ) ? $plugin_data['RequiresWP'] : '',
+			'requires_php'     => ! empty( $plugin_data['RequiresPHP'] ) ? $plugin_data['RequiresPHP'] : '',
+			'requires_plugins' => ! empty( $plugin_data['RequiresPlugins'] ) ? $plugin_data['RequiresPlugins'] : '',
 		];
-
-		$require_fields = [
-			'requires_wp'      => 'RequiresWP',
-			'requires_php'     => 'RequiresPHP',
-			'requires_plugins' => 'RequiresPlugins',
-		];
-
-		foreach ( $require_fields as $field_key => $data_key ) {
-			if ( isset( $plugin_data[ $data_key ] ) && ! empty( $plugin_data[ $data_key ] ) ) {
-				$plugin_obj->{$field_key} = $plugin_data[ $data_key ];
-			}
-		}
 
 		if ( empty( $assoc_args['fields'] ) ) {
 			$assoc_args['fields'] = $default_fields;

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -941,10 +941,28 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *   - yaml
 	 * ---
 	 *
+	 * ## AVAILABLE FIELDS
+	 *
+	 * These fields will be displayed by default for the plugin:
+	 *
+	 * * name
+	 * * title
+	 * * author
+	 * * version
+	 * * description
+	 * * status
+	 *
+	 * These fields are optionally available:
+	 *
+	 * * requires_wp
+	 * * requires_php
+	 * * requires_plugins
+	 *
 	 * ## EXAMPLES
 	 *
+	 *     # Get plugin details.
 	 *     $ wp plugin get bbpress --format=json
-	 *     {"name":"bbpress","title":"bbPress","author":"The bbPress Contributors","version":"2.6-alpha","description":"bbPress is forum software with a twist from the creators of WordPress.","status":"active"}
+	 *     {"name":"bbpress","title":"bbPress","author":"The bbPress Contributors","version":"2.6.9","description":"bbPress is forum software with a twist from the creators of WordPress.","status":"active"}
 	 */
 	public function get( $args, $assoc_args ) {
 		$default_fields = array(


### PR DESCRIPTION
* Plugin header `RequiresPlugins` is also displayed if exists.
* Added feature test for plugin get. One scenario for `RequiresPlugins` and one with basic test in separate file `plugin-get.feature`

Related: https://github.com/wp-cli/extension-command/issues/407