### PR TITLE
Update the theme in feature tests

### DIFF
--- a/features/theme-delete.feature
+++ b/features/theme-delete.feature
@@ -2,32 +2,32 @@ Feature: Delete WordPress themes
 
   Background:
     Given a WP install
-    And I run `wp theme install twentytwelve`
+    And I run `wp theme install twentytwelve --force`
 
   Scenario: Delete an installed theme
-    When I run `wp theme delete p2`
+    When I run `wp theme delete twentytwelve`
     Then STDOUT should be:
       """
-      Deleted 'p2' theme.
+      Deleted 'twentytwelve' theme.
       Success: Deleted 1 of 1 themes.
       """
     And the return code should be 0
 
   Scenario: Delete an active theme
-    When I run `wp theme activate p2`
+    When I run `wp theme activate twentytwelve`
     Then STDOUT should not be empty
 
-    When I try `wp theme delete p2`
+    When I try `wp theme delete twentytwelve`
     Then STDERR should be:
       """
-      Warning: Can't delete the currently active theme: p2
+      Warning: Can't delete the currently active theme: twentytwelve
       Error: No themes deleted.
       """
 
-    When I try `wp theme delete p2 --force`
+    When I try `wp theme delete twentytwelve --force`
     Then STDOUT should contain:
       """
-      Deleted 'p2' theme.
+      Deleted 'twentytwelve' theme.
       """
 
   Scenario: Delete all installed themes
@@ -108,7 +108,7 @@ Feature: Delete WordPress themes
     Then STDOUT should be empty
 
   Scenario: Attempting to delete a theme that doesn't exist
-    When I run `wp theme delete p2`
+    When I run `wp theme delete twentytwelve`
     Then STDOUT should not be empty
 
     When I try the previous command again
@@ -118,6 +118,6 @@ Feature: Delete WordPress themes
       """
     And STDERR should be:
       """
-      Warning: The 'p2' theme could not be found.
+      Warning: The 'twentytwelve' theme could not be found.
       """
     And the return code should be 0

--- a/features/theme-delete.feature
+++ b/features/theme-delete.feature
@@ -2,7 +2,7 @@ Feature: Delete WordPress themes
 
   Background:
     Given a WP install
-    And I run `wp theme install p2`
+    And I run `wp theme install twentytwelve`
 
   Scenario: Delete an installed theme
     When I run `wp theme delete p2`

--- a/features/theme-delete.feature
+++ b/features/theme-delete.feature
@@ -2,7 +2,9 @@ Feature: Delete WordPress themes
 
   Background:
     Given a WP install
-    And I run `wp theme install twentytwelve --force`
+    And I run `wp theme delete --all --force`
+    And I run `wp theme install twentytwelve`
+    And I run `wp theme install twentyeleven --activate`
 
   Scenario: Delete an installed theme
     When I run `wp theme delete twentytwelve`

--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -3,7 +3,7 @@ Feature: Install WordPress themes
   Scenario: Return code is 1 when one or more theme installations fail
     Given a WP install
 
-    When I try `wp theme install p2 p2-not-a-theme`
+    When I try `wp theme install twentytwelve p2-not-a-theme`
     Then STDERR should contain:
       """
       Warning:
@@ -26,7 +26,7 @@ Feature: Install WordPress themes
       """
     And the return code should be 1
 
-    When I try `wp theme install p2`
+    When I try `wp theme install twentytwelve`
     Then STDOUT should be:
       """
       Success: Theme already installed.
@@ -37,7 +37,7 @@ Feature: Install WordPress themes
       """
     And the return code should be 0
 
-    When I try `wp theme install p2-not-a-theme`
+    When I try `wp theme install twentytwelve-not-a-theme`
     Then STDERR should contain:
       """
       Warning:
@@ -90,10 +90,10 @@ Feature: Install WordPress themes
   Scenario: Verify installed theme activation
     Given a WP install
 
-    When I run `wp theme install p2`
+    When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
 
-    When I try `wp theme install p2 --activate`
+    When I try `wp theme install twentytwelve --activate`
     Then STDERR should contain:
     """
     Warning: p2: Theme already installed.

--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -2,7 +2,7 @@ Feature: Install WordPress themes
 
   Background:
     Given a WP install
-    And I try `wp theme delete twentytwelve --force`
+    And I run `wp theme delete --all --force`
 
   Scenario: Return code is 1 when one or more theme installations fail
     When I try `wp theme install twentytwelve twentytwelve-not-a-theme`

--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -1,16 +1,18 @@
 Feature: Install WordPress themes
 
-  Scenario: Return code is 1 when one or more theme installations fail
+  Background:
     Given a WP install
+    And I try `wp theme delete twentytwelve --force`
 
-    When I try `wp theme install twentytwelve p2-not-a-theme`
+  Scenario: Return code is 1 when one or more theme installations fail
+    When I try `wp theme install twentytwelve twentytwelve-not-a-theme`
     Then STDERR should contain:
       """
       Warning:
       """
     And STDERR should contain:
       """
-      p2-not-a-theme
+      twentytwelve-not-a-theme
       """
     And STDERR should contain:
       """
@@ -18,7 +20,7 @@ Feature: Install WordPress themes
       """
     And STDOUT should contain:
       """
-      Installing P2
+      Installing Twenty Twelve
       """
     And STDOUT should contain:
       """
@@ -33,7 +35,7 @@ Feature: Install WordPress themes
       """
     And STDERR should be:
       """
-      Warning: p2: Theme already installed.
+      Warning: twentytwelve: Theme already installed.
       """
     And the return code should be 0
 
@@ -44,7 +46,7 @@ Feature: Install WordPress themes
       """
     And STDERR should contain:
       """
-      p2-not-a-theme
+      twentytwelve-not-a-theme
       """
     And STDERR should contain:
       """
@@ -88,20 +90,18 @@ Feature: Install WordPress themes
       """
 
   Scenario: Verify installed theme activation
-    Given a WP install
-
     When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
 
     When I try `wp theme install twentytwelve --activate`
     Then STDERR should contain:
     """
-    Warning: p2: Theme already installed.
+    Warning: twentytwelve: Theme already installed.
     """
 
     And STDOUT should contain:
     """
-    Activating 'p2'...
-    Success: Switched to 'P2' theme.
+    Activating 'twentytwelve'...
+    Success: Switched to 'Twenty Twelve' theme.
     Success: Theme already installed.
     """

--- a/features/theme-update.feature
+++ b/features/theme-update.feature
@@ -20,7 +20,7 @@ Feature: Update WordPress themes
   Scenario: Install a theme, then update to a specific version of that theme
     Given a WP install
 
-    When I run `wp theme install p2 --version=1.4.1`
+    When I run `wp theme install twentytwelve --version=1.4.1`
     Then STDOUT should not be empty
 
     When I run `wp theme update p2 --version=1.4.2`
@@ -51,7 +51,7 @@ Feature: Update WordPress themes
       """
 
     # One theme installed.
-    Given I run `wp theme install p2 --version=1.4.2`
+    Given I run `wp theme install twentytwelve --version=1.4.2`
 
     When I try `wp theme update`
     Then the return code should be 1
@@ -113,7 +113,7 @@ Feature: Update WordPress themes
       """
       Error: Can't find the requested theme's version 1.4.2 in the WordPress.org theme repository (HTTP code 404).
       """
-  
+
   Scenario: Error when both --minor and --patch are provided
     Given a WP install
 
@@ -139,7 +139,7 @@ Feature: Update WordPress themes
       """
       3.9
       """
-  
+
   Scenario: Update a theme to its latest patch release
     Given a WP install
     And I run `wp theme install --force twentytwelve --version=1.1`

--- a/features/theme-update.feature
+++ b/features/theme-update.feature
@@ -19,17 +19,18 @@ Feature: Update WordPress themes
 
   Scenario: Install a theme, then update to a specific version of that theme
     Given a WP install
+    And I run `wp theme delete twentytwelve --force`
 
-    When I run `wp theme install twentytwelve --version=1.4.1`
+    When I run `wp theme install twentytwelve --version=3.0`
     Then STDOUT should not be empty
 
-    When I run `wp theme update p2 --version=1.4.2`
+    When I run `wp theme update twentytwelve --version=4.0`
     Then STDOUT should not be empty
 
     When I run `wp theme list --fields=name,version`
     Then STDOUT should be a table containing rows:
-      | name       | version   |
-      | p2         | 1.4.2     |
+      | name         | version   |
+      | twentytwelve | 4.0       |
 
   Scenario: Not giving a slug on update should throw an error unless --all given
     Given a WP install
@@ -51,7 +52,7 @@ Feature: Update WordPress themes
       """
 
     # One theme installed.
-    Given I run `wp theme install twentytwelve --version=1.4.2`
+    Given I run `wp theme install twentytwelve --version=1.4`
 
     When I try `wp theme update`
     Then the return code should be 1
@@ -74,7 +75,7 @@ Feature: Update WordPress themes
       """
 
     # Note: if given version then re-installs.
-    When I run `wp theme update --version=1.4.2 --all`
+    When I run `wp theme update --version=1.4 --all`
     Then STDOUT should contain:
       """
       Success: Installed 1 of 1 themes.
@@ -87,7 +88,7 @@ Feature: Update WordPress themes
       """
 
     # Two themes installed.
-    Given I run `wp theme install --force twentytwelve --version=1.0`
+    Given I run `wp theme install --force twentytwentyfour --version=1.1`
 
     When I run `wp theme update --all`
     Then STDOUT should contain:
@@ -103,7 +104,8 @@ Feature: Update WordPress themes
       """
 
     # Using version with all rarely makes sense and should probably error and do nothing.
-    When I try `wp theme update --version=1.4.2 --all`
+    # Version 1.1.1 is available for twentytwelve but not for twentytwentyfour.
+    When I try `wp theme update --version=1.1.1 --all`
     Then the return code should be 1
     And STDOUT should contain:
       """
@@ -111,7 +113,7 @@ Feature: Update WordPress themes
       """
     And STDERR should be:
       """
-      Error: Can't find the requested theme's version 1.4.2 in the WordPress.org theme repository (HTTP code 404).
+      Error: Can't find the requested theme's version 1.1.1 in the WordPress.org theme repository (HTTP code 404).
       """
 
   Scenario: Error when both --minor and --patch are provided

--- a/features/theme-update.feature
+++ b/features/theme-update.feature
@@ -52,7 +52,7 @@ Feature: Update WordPress themes
       """
 
     # One theme installed.
-    Given I run `wp theme install twentytwelve --version=1.4`
+    Given I run `wp theme install moina --version=1.0.2`
 
     When I try `wp theme update`
     Then the return code should be 1
@@ -75,7 +75,7 @@ Feature: Update WordPress themes
       """
 
     # Note: if given version then re-installs.
-    When I run `wp theme update --version=1.4 --all`
+    When I run `wp theme update --version=1.0.2 --all`
     Then STDOUT should contain:
       """
       Success: Installed 1 of 1 themes.
@@ -88,7 +88,7 @@ Feature: Update WordPress themes
       """
 
     # Two themes installed.
-    Given I run `wp theme install --force twentytwentyfour --version=1.1`
+    Given I run `wp theme install --force twentytwelve --version=1.0`
 
     When I run `wp theme update --all`
     Then STDOUT should contain:
@@ -104,8 +104,7 @@ Feature: Update WordPress themes
       """
 
     # Using version with all rarely makes sense and should probably error and do nothing.
-    # Version 1.1.1 is available for twentytwelve but not for twentytwentyfour.
-    When I try `wp theme update --version=1.1.1 --all`
+    When I try `wp theme update --version=1.0.3 --all`
     Then the return code should be 1
     And STDOUT should contain:
       """
@@ -113,7 +112,7 @@ Feature: Update WordPress themes
       """
     And STDERR should be:
       """
-      Error: Can't find the requested theme's version 1.1.1 in the WordPress.org theme repository (HTTP code 404).
+      Error: Can't find the requested theme's version 1.0.3 in the WordPress.org theme repository (HTTP code 404).
       """
 
   Scenario: Error when both --minor and --patch are provided

--- a/features/theme-update.feature
+++ b/features/theme-update.feature
@@ -19,7 +19,7 @@ Feature: Update WordPress themes
 
   Scenario: Install a theme, then update to a specific version of that theme
     Given a WP install
-    And I run `wp theme delete twentytwelve --force`
+    And I run `wp theme delete --all --force`
 
     When I run `wp theme install twentytwelve --version=3.0`
     Then STDOUT should not be empty

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -2,36 +2,37 @@ Feature: Manage WordPress themes
 
   Scenario: Installing and deleting theme
     Given a WP install
+    And I run `wp theme delete twentytwelve --force`
 
     When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
 
-    When I run `wp theme status p2`
+    When I run `wp theme status twentytwelve`
     Then STDOUT should contain:
       """
-      Theme p2 details:
-          Name: P2
+      Theme twentytwelve details:
+          Name: Twenty Twelve
       """
 
-    When I run `wp theme path p2`
+    When I run `wp theme path twentytwelve`
     Then STDOUT should contain:
       """
-      /themes/p2/style.css
+      /themes/twentytwelve/style.css
       """
 
     When I run `wp option get stylesheet`
     Then save STDOUT as {PREVIOUS_THEME}
 
-    When I run `wp theme activate p2`
+    When I run `wp theme activate twentytwelve`
     Then STDOUT should be:
       """
-      Success: Switched to 'P2' theme.
+      Success: Switched to 'Twenty Twelve' theme.
       """
 
-    When I try `wp theme delete p2`
+    When I try `wp theme delete twentytwelve`
     Then STDERR should be:
       """
-      Warning: Can't delete the currently active theme: p2
+      Warning: Can't delete the currently active theme: twentytwelve
       Error: No themes deleted.
       """
     And STDOUT should be empty
@@ -40,13 +41,13 @@ Feature: Manage WordPress themes
     When I run `wp theme activate {PREVIOUS_THEME}`
     Then STDOUT should not be empty
 
-    When I run `wp theme delete p2`
+    When I run `wp theme delete twentytwelve`
     Then STDOUT should not be empty
 
     When I try the previous command again
     Then STDERR should be:
       """
-      Warning: The 'p2' theme could not be found.
+      Warning: The 'twentytwelve' theme could not be found.
       """
     And STDOUT should be:
       """
@@ -73,20 +74,21 @@ Feature: Manage WordPress themes
 
   Scenario: Install a theme, activate, then force install an older version of the theme
     Given a WP install
+    And I run `wp theme delete twentytwelve --force`
 
-    When I run `wp theme install twentytwelve --version=1.4.2`
+    When I run `wp theme install twentytwelve --version=1.4`
     Then STDOUT should not be empty
 
-    When I run `wp theme list --name=p2 --field=update_version`
+    When I run `wp theme list --name=twentytwelve --field=update_version`
     Then STDOUT should not be empty
     And save STDOUT as {UPDATE_VERSION}
 
     When I run `wp theme list`
     Then STDOUT should be a table containing rows:
-      | name  | status   | update    | version   | update_version   | auto_update |
-      | p2    | inactive | available | 1.4.2     | {UPDATE_VERSION} | off         |
+      | name            | status   | update    | version | update_version   | auto_update |
+      | twentytwelve    | inactive | available | 1.4     | {UPDATE_VERSION} | off         |
 
-    When I run `wp theme activate p2`
+    When I run `wp theme activate twentytwelve`
     Then STDOUT should not be empty
 
     # Ensure no other themes interfere with update.
@@ -96,13 +98,13 @@ Feature: Manage WordPress themes
       Success: Deleted
       """
 
-    When I run `wp theme install twentytwelve --version=1.4.1 --force`
+    When I run `wp theme install twentytwelve --version=1.5 --force`
     Then STDOUT should not be empty
 
     When I run `wp theme list`
     Then STDOUT should be a table containing rows:
-      | name  | status   | update    | version   | update_version   | auto_update |
-      | p2    | active   | available | 1.4.1     | {UPDATE_VERSION} | off         |
+      | name            | status   | update    | version | update_version   | auto_update |
+      | twentytwelve    | active   | available | 1.5     | {UPDATE_VERSION} | off         |
 
     When I try `wp theme update`
     Then STDERR should be:
@@ -114,10 +116,10 @@ Feature: Manage WordPress themes
     When I run `wp theme update --all --format=summary | grep 'updated successfully from'`
     Then STDOUT should contain:
       """
-      P2 updated successfully from version 1.4.1 to version
+      Twenty Twelve updated successfully from version 1.5 to version
       """
 
-    When I run `wp theme install twentytwelve --version=1.4.1 --force`
+    When I run `wp theme install twentytwelve --version=1.4 --force`
     Then STDOUT should not be empty
 
     When I run `wp theme update --all`
@@ -128,18 +130,19 @@ Feature: Manage WordPress themes
 
   Scenario: Exclude theme from bulk updates.
     Given a WP install
+    And I run `wp theme delete twentytwelve --force`
 
-    When I run `wp theme install twentytwelve --version=1.4.1 --force`
+    When I run `wp theme install twentytwelve --version=1.4 --force`
     Then STDOUT should contain:
       """
       Downloading install
       """
     And STDOUT should contain:
       """
-      package from https://downloads.wordpress.org/theme/p2.1.4.1.zip...
+      package from https://downloads.wordpress.org/theme/twentytwelve.1.4.zip...
       """
 
-    When I run `wp theme activate p2`
+    When I run `wp theme activate twentytwelve`
     Then STDOUT should not be empty
 
     # Ensure no other themes interfere with update.
@@ -149,19 +152,19 @@ Feature: Manage WordPress themes
       Success: Deleted
       """
 
-    When I run `wp theme status p2`
+    When I run `wp theme status twentytwelve`
     Then STDOUT should contain:
       """
       Update available
       """
 
-    When I run `wp theme update --all --exclude=p2 | grep 'Skipped'`
+    When I run `wp theme update --all --exclude=twentytwelve | grep 'Skipped'`
     Then STDOUT should contain:
       """
-      p2
+      twentytwelve
       """
 
-    When I run `wp theme status p2`
+    When I run `wp theme status twentytwelve`
     Then STDOUT should contain:
       """
       Update available
@@ -169,32 +172,34 @@ Feature: Manage WordPress themes
 
   Scenario: Get the path of an installed theme
     Given a WP install
+    And I run `wp theme delete twentytwelve --force`
 
     When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
 
-    When I run `wp theme path p2 --dir`
+    When I run `wp theme path twentytwelve --dir`
     Then STDOUT should contain:
        """
-       wp-content/themes/p2
+       wp-content/themes/twentytwelve
        """
 
   Scenario: Activate an already active theme
     Given a WP install
+    And I run `wp theme delete twentytwelve --force`
 
     When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
 
-    When I run `wp theme activate p2`
+    When I run `wp theme activate twentytwelve`
     Then STDOUT should be:
       """
-      Success: Switched to 'P2' theme.
+      Success: Switched to 'Twenty Twelve' theme.
       """
 
-    When I try `wp theme activate p2`
+    When I try `wp theme activate twentytwelve`
     Then STDERR should be:
       """
-      Warning: The 'P2' theme is already active.
+      Warning: The 'Twenty Twelve' theme is already active.
       """
     And STDOUT should be empty
     And the return code should be 0
@@ -236,8 +241,8 @@ Feature: Manage WordPress themes
 
     When I run `wp theme list --fields=name,status`
     Then STDOUT should be a table containing rows:
-      | name  | status   |
-      | p2    | active   |
+      | name            | status   |
+      | twentytwelve    | active   |
 
   Scenario: Attempt to activate or fetch a broken theme
     Given a WP install
@@ -354,7 +359,7 @@ Feature: Manage WordPress themes
   Scenario: Enabling and disabling a theme without multisite
   	Given a WP install
 
-    When I try `wp theme enable p2`
+    When I try `wp theme enable twentytwelve`
     Then STDERR should contain:
       """
       Error: This is not a multisite install
@@ -362,7 +367,7 @@ Feature: Manage WordPress themes
     And STDOUT should be empty
     And the return code should be 1
 
-    When I try `wp theme disable p2`
+    When I try `wp theme disable twentytwelve`
     Then STDERR should contain:
       """
       Error: This is not a multisite install
@@ -485,25 +490,26 @@ Feature: Manage WordPress themes
 
   Scenario: Get status field in theme detail
     Given a WP install
+    And I run `wp theme delete twentytwelve --force`
 
     When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
 
-    When I run `wp theme get p2`
+    When I run `wp theme get twentytwelve`
     Then STDOUT should be a table containing rows:
     | Field   | Value     |
     | status  | inactive  |
 
-    When I run `wp theme get p2 --field=status`
+    When I run `wp theme get twentytwelve --field=status`
     Then STDOUT should be:
        """
        inactive
        """
 
-    When I run `wp theme activate p2`
+    When I run `wp theme activate twentytwelve`
     Then STDOUT should not be empty
 
-    When I run `wp theme get p2 --field=status`
+    When I run `wp theme get twentytwelve --field=status`
     Then STDOUT should be:
        """
        active
@@ -511,30 +517,31 @@ Feature: Manage WordPress themes
 
   Scenario: Theme activation fails when slug does not match exactly
     Given a WP install
+    And I run `wp theme delete twentytwelve --force`
 
     When I run `wp theme install twentytwelve`
     Then the return code should be 0
 
-    When I try `wp theme activate P2`
+    When I try `wp theme activate TwentyTwelve`
     Then STDERR should contain:
       """
-      Error: The 'P2' theme could not be found. Did you mean 'p2'?
+      Error: The 'TwentyTwelve' theme could not be found. Did you mean 'twentytwelve'?
       """
     And STDOUT should be empty
     And the return code should be 1
 
-    When I try `wp theme activate p3`
+    When I try `wp theme activate twentytwelve3`
     Then STDERR should contain:
       """
-      Error: The 'p3' theme could not be found. Did you mean 'p2'?
+      Error: The 'twentytwelve3' theme could not be found. Did you mean 'twentytwelve'?
       """
     And STDOUT should be empty
     And the return code should be 1
 
-    When I try `wp theme activate pb2`
+    When I try `wp theme activate twentytwelves2`
     Then STDERR should contain:
       """
-      Error: The 'pb2' theme could not be found. Did you mean 'p2'?
+      Error: The 'twentytwelves2' theme could not be found. Did you mean 'twentytwelve'?
       """
     And STDOUT should be empty
     And the return code should be 1
@@ -569,6 +576,8 @@ Feature: Manage WordPress themes
 
   Scenario: Parent theme is active when its child is active
     Given a WP install
+    And I run `wp theme delete twentytwelve --force`
+
     And I run `wp theme install twentytwelve`
     And I run `wp theme install moina-blog --activate`
 
@@ -578,13 +587,13 @@ Feature: Manage WordPress themes
     When I run `wp theme is-active moina`
     Then the return code should be 0
 
-    When I try `wp theme is-active p2`
+    When I try `wp theme is-active twentytwelve`
     Then the return code should be 1
 
   Scenario: Excluding a missing theme should not throw an error
     Given a WP install
     And I run `wp theme delete --all --force`
-    And I run `wp theme install twentytwelve --version=1.5.5 --activate`
+    And I run `wp theme install twentytwelve --version=1.5 --activate`
     And I run `wp theme update --all --exclude=missing-theme`
     Then STDERR should be empty
     And STDOUT should contain:

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -2,7 +2,8 @@ Feature: Manage WordPress themes
 
   Scenario: Installing and deleting theme
     Given a WP install
-    And I run `wp theme delete twentytwelve --force`
+    And I run `wp theme delete --all --force`
+    And I run `wp theme install twentyeleven --activate`
 
     When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
@@ -74,7 +75,8 @@ Feature: Manage WordPress themes
 
   Scenario: Install a theme, activate, then force install an older version of the theme
     Given a WP install
-    And I run `wp theme delete twentytwelve --force`
+    And I run `wp theme delete --all --force`
+    And I run `wp theme install twentyeleven --activate`
 
     When I run `wp theme install twentytwelve --version=1.4`
     Then STDOUT should not be empty
@@ -130,7 +132,8 @@ Feature: Manage WordPress themes
 
   Scenario: Exclude theme from bulk updates.
     Given a WP install
-    And I run `wp theme delete twentytwelve --force`
+    And I run `wp theme delete --all --force`
+    And I run `wp theme install twentyeleven --activate`
 
     When I run `wp theme install twentytwelve --version=1.4 --force`
     Then STDOUT should contain:
@@ -172,7 +175,7 @@ Feature: Manage WordPress themes
 
   Scenario: Get the path of an installed theme
     Given a WP install
-    And I run `wp theme delete twentytwelve --force`
+    And I run `wp theme delete --all --force`
 
     When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
@@ -185,7 +188,7 @@ Feature: Manage WordPress themes
 
   Scenario: Activate an already active theme
     Given a WP install
-    And I run `wp theme delete twentytwelve --force`
+    And I run `wp theme delete --all --force`
 
     When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
@@ -231,6 +234,7 @@ Feature: Manage WordPress themes
 
   Scenario: Install a theme when the theme directory doesn't yet exist
     Given a WP install
+    And I run `wp theme delete --all --force`
 
     When I run `rm -rf wp-content/themes`
     And I run `if test -d wp-content/themes; then echo "fail"; fi`
@@ -402,6 +406,7 @@ Feature: Manage WordPress themes
 
   Scenario: When updating a theme --format should be the same when using --dry-run
     Given a WP install
+    And I run `wp theme delete --all --force`
 
     When I run `wp theme install --force twentytwelve --version=1.0`
     Then STDOUT should not be empty
@@ -441,6 +446,7 @@ Feature: Manage WordPress themes
 
   Scenario: Check json and csv formats when updating a theme
     Given a WP install
+    And I run `wp theme delete --all --force`
 
     When I run `wp theme install --force twentytwelve --version=1.0`
     Then STDOUT should not be empty
@@ -490,7 +496,7 @@ Feature: Manage WordPress themes
 
   Scenario: Get status field in theme detail
     Given a WP install
-    And I run `wp theme delete twentytwelve --force`
+    And I run `wp theme delete --all --force`
 
     When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
@@ -517,7 +523,7 @@ Feature: Manage WordPress themes
 
   Scenario: Theme activation fails when slug does not match exactly
     Given a WP install
-    And I run `wp theme delete twentytwelve --force`
+    And I run `wp theme delete --all --force`
 
     When I run `wp theme install twentytwelve`
     Then the return code should be 0
@@ -576,8 +582,7 @@ Feature: Manage WordPress themes
 
   Scenario: Parent theme is active when its child is active
     Given a WP install
-    And I run `wp theme delete twentytwelve --force`
-
+    And I run `wp theme delete --all --force`
     And I run `wp theme install twentytwelve`
     And I run `wp theme install moina-blog --activate`
 

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -3,7 +3,7 @@ Feature: Manage WordPress themes
   Scenario: Installing and deleting theme
     Given a WP install
 
-    When I run `wp theme install p2`
+    When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
 
     When I run `wp theme status p2`
@@ -74,7 +74,7 @@ Feature: Manage WordPress themes
   Scenario: Install a theme, activate, then force install an older version of the theme
     Given a WP install
 
-    When I run `wp theme install p2 --version=1.4.2`
+    When I run `wp theme install twentytwelve --version=1.4.2`
     Then STDOUT should not be empty
 
     When I run `wp theme list --name=p2 --field=update_version`
@@ -96,7 +96,7 @@ Feature: Manage WordPress themes
       Success: Deleted
       """
 
-    When I run `wp theme install p2 --version=1.4.1 --force`
+    When I run `wp theme install twentytwelve --version=1.4.1 --force`
     Then STDOUT should not be empty
 
     When I run `wp theme list`
@@ -117,7 +117,7 @@ Feature: Manage WordPress themes
       P2 updated successfully from version 1.4.1 to version
       """
 
-    When I run `wp theme install p2 --version=1.4.1 --force`
+    When I run `wp theme install twentytwelve --version=1.4.1 --force`
     Then STDOUT should not be empty
 
     When I run `wp theme update --all`
@@ -129,7 +129,7 @@ Feature: Manage WordPress themes
   Scenario: Exclude theme from bulk updates.
     Given a WP install
 
-    When I run `wp theme install p2 --version=1.4.1 --force`
+    When I run `wp theme install twentytwelve --version=1.4.1 --force`
     Then STDOUT should contain:
       """
       Downloading install
@@ -170,7 +170,7 @@ Feature: Manage WordPress themes
   Scenario: Get the path of an installed theme
     Given a WP install
 
-    When I run `wp theme install p2`
+    When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
 
     When I run `wp theme path p2 --dir`
@@ -182,7 +182,7 @@ Feature: Manage WordPress themes
   Scenario: Activate an already active theme
     Given a WP install
 
-    When I run `wp theme install p2`
+    When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
 
     When I run `wp theme activate p2`
@@ -231,7 +231,7 @@ Feature: Manage WordPress themes
     And I run `if test -d wp-content/themes; then echo "fail"; fi`
     Then STDOUT should be empty
 
-    When I run `wp theme install p2 --activate`
+    When I run `wp theme install twentytwelve --activate`
     Then STDOUT should not be empty
 
     When I run `wp theme list --fields=name,status`
@@ -486,7 +486,7 @@ Feature: Manage WordPress themes
   Scenario: Get status field in theme detail
     Given a WP install
 
-    When I run `wp theme install p2`
+    When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
 
     When I run `wp theme get p2`
@@ -512,7 +512,7 @@ Feature: Manage WordPress themes
   Scenario: Theme activation fails when slug does not match exactly
     Given a WP install
 
-    When I run `wp theme install p2`
+    When I run `wp theme install twentytwelve`
     Then the return code should be 0
 
     When I try `wp theme activate P2`
@@ -569,7 +569,7 @@ Feature: Manage WordPress themes
 
   Scenario: Parent theme is active when its child is active
     Given a WP install
-    And I run `wp theme install p2`
+    And I run `wp theme install twentytwelve`
     And I run `wp theme install moina-blog --activate`
 
     When I run `wp theme is-active moina-blog`
@@ -584,7 +584,7 @@ Feature: Manage WordPress themes
   Scenario: Excluding a missing theme should not throw an error
     Given a WP install
     And I run `wp theme delete --all --force`
-    And I run `wp theme install p2 --version=1.5.5 --activate`
+    And I run `wp theme install twentytwelve --version=1.5.5 --activate`
     And I run `wp theme update --all --exclude=missing-theme`
     Then STDERR should be empty
     And STDOUT should contain:

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -208,5 +208,5 @@ Feature: Manage WordPress themes and plugins
 
     Examples:
       | type   | type_name | item                    | item_title              | version | zip_file                                                               | file_to_check                                                     |
-      | theme  | Theme     | p2                      | P2                      | 1.0.1   | https://wordpress.org/themes/download/p2.1.0.1.zip                     | {CONTENT_DIR}/p2/style.css                                        |
+      | theme  | Theme     | moina                      | Moina                      | 1.1.2   | https://wordpress.org/themes/download/moina.1.1.2.zip                     | {CONTENT_DIR}/moina/style.css                                        |
       | plugin | Plugin    | category-checklist-tree | Category Checklist Tree | 1.2     | https://downloads.wordpress.org/plugin/category-checklist-tree.1.2.zip | {CONTENT_DIR}/category-checklist-tree/category-checklist-tree.php |


### PR DESCRIPTION
This Pull Request updates the theme to install in the feature tests from `p2` to `twentytwelve` since the `p2` has been removed from WP.org repository.

### Reference 

- https://github.com/wp-cli/wp-cli-tests/issues/200
- https://themes.trac.wordpress.org/ticket/30322 