### PR TITLE
Replace User Switching from feature tests

### DIFF
--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -40,8 +40,8 @@ Feature: Activate WordPress plugins
       """
       <?php
       /**
-       * Plugin Name: Hide User Switching on Production
-       * Description: Hides the User Switching plugin on production sites
+       * Plugin Name: Hide Site Secrets on Production
+       * Description: Hides the Site Secrets plugin on production sites
        * Author: WP-CLI tests
        */
 


### PR DESCRIPTION
Fixes https://github.com/wp-cli/extension-command/issues/387

* It seems plugin has been replaced already. Only some crufts remaining. I have fixed those lines. So this PR should be able to close https://github.com/wp-cli/extension-command/issues/387