### PR TITLE
Improve warning message for install and activate multiple themes

### DIFF
--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -109,6 +109,19 @@ Feature: Install WordPress themes
   Scenario: Installation of multiple themes with activate
     When I try `wp theme install twentytwelve twentyeleven --activate`
     Then STDERR should contain:
-    """
-    Warning: Only a single theme can be active.
-    """
+      """
+      Warning: Only this single theme will be activated: twentyeleven
+      """
+
+    When I run `wp theme list --field=name`
+    Then STDOUT should contain:
+      """
+      twentyeleven
+      twentytwelve
+      """
+
+    When I run `wp theme list --field=name --status=active`
+    Then STDOUT should contain:
+      """
+      twentyeleven
+      """

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -489,7 +489,7 @@ class Theme_Command extends CommandWithUpgrade {
 	 */
 	public function install( $args, $assoc_args ) {
 		if ( count( $args ) > 1 && Utils\get_flag_value( $assoc_args, 'activate', false ) ) {
-			WP_CLI::warning( sprintf( "Only this single theme will be activated: %s", end( $args ) ) );
+			WP_CLI::warning( sprintf( 'Only this single theme will be activated: %s', end( $args ) ) );
 			reset( $args );
 		}
 

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -489,7 +489,8 @@ class Theme_Command extends CommandWithUpgrade {
 	 */
 	public function install( $args, $assoc_args ) {
 		if ( count( $args ) > 1 && Utils\get_flag_value( $assoc_args, 'activate', false ) ) {
-			WP_CLI::warning( 'Only a single theme can be active.' );
+			WP_CLI::warning( sprintf( "Only this single theme will be activated: %s", end( $args ) ) );
+			reset( $args );
 		}
 
 		$theme_root = get_theme_root();


### PR DESCRIPTION
Improves the warning message present when `wp theme install --activate` is used with multiple themes:

**Before**:

```
$ wp theme install twentytwelve twentyeleven --activate
Warning: Only a single theme can be active.
```

**After:**

```
$ wp theme install twentytwelve twentyeleven --activate
Warning: Only this single theme will be activated: twentyeleven
```

From https://github.com/wp-cli/extension-command/pull/408
Related https://github.com/wp-cli/extension-command/issues/406
Related https://github.com/wp-cli/wp-cli/issues/5935