### PR TITLE
Add `--recently-active` option in plugin list command

### DIFF
--- a/features/plugin-list-recently-active.feature
+++ b/features/plugin-list-recently-active.feature
@@ -1,0 +1,146 @@
+Feature: List recently active WordPress plugins
+
+  Scenario: Verify plugin installation, activation, deactivation and confirm listing recently active plugins list is correct
+    Given a WP install
+
+    When I run `wp plugin install site-secrets debug-bar p2-by-email --activate`
+    Then STDOUT should contain:
+      """
+      Plugin 'site-secrets' activated.
+      """
+    And STDOUT should contain:
+      """
+      Plugin 'debug-bar' activated.
+      """
+    And STDOUT should contain:
+      """
+      Plugin 'p2-by-email' activated.
+      """
+
+    When I run `wp plugin list --recently-active --field=name --format=json`
+    Then STDOUT should be:
+      """
+      []
+      """
+
+    When I run `wp plugin activate akismet`
+    Then STDOUT should contain:
+      """
+      Plugin 'akismet' activated.
+      """
+
+    When I run `wp plugin deactivate site-secrets debug-bar`
+    Then STDOUT should contain:
+      """
+      Plugin 'site-secrets' deactivated.
+      Plugin 'debug-bar' deactivated.
+      Success: Deactivated 2 of 2 plugins.
+      """
+
+    When I run `wp plugin list --recently-active --field=name`
+    Then STDOUT should be a table containing rows:
+      | debug-bar    |
+      | site-secrets |
+
+  Scenario: Use recently active plugin to activate plugins
+    Given a WP install
+
+    When I run `wp plugin install site-secrets debug-bar --activate`
+    Then STDOUT should contain:
+      """
+      Plugin 'site-secrets' activated.
+      """
+    And STDOUT should contain:
+      """
+      Plugin 'debug-bar' activated.
+      """
+
+    When I run `wp plugin deactivate site-secrets debug-bar`
+    Then STDOUT should be:
+      """
+      Plugin 'site-secrets' deactivated.
+      Plugin 'debug-bar' deactivated.
+      Success: Deactivated 2 of 2 plugins.
+      """
+
+    When I run `wp plugin activate $(wp plugin list --recently-active --field=name)`
+    Then STDOUT should contain:
+      """
+      Plugin 'debug-bar' activated.
+      """
+    And STDOUT should contain:
+      """
+      Plugin 'site-secrets' activated.
+      """
+
+  Scenario: For a MU site, verify plugin installation, activation, deactivation and confirm listing recently active plugins list is correct
+    Given a WP multisite install
+
+    When I run `wp plugin install site-secrets debug-bar p2-by-email --activate-network`
+    Then STDOUT should contain:
+      """
+      Plugin 'site-secrets' network activated.
+      """
+    And STDOUT should contain:
+      """
+      Plugin 'debug-bar' network activated.
+      """
+    And STDOUT should contain:
+      """
+      Plugin 'p2-by-email' network activated.
+      """
+
+    When I run `wp plugin activate akismet --network`
+    Then STDOUT should contain:
+      """
+      Plugin 'akismet' network activated.
+      """
+
+    When I run `wp plugin list --recently-active --field=name --format=json`
+    Then STDOUT should be:
+      """
+      []
+      """
+    When I run `wp plugin deactivate site-secrets debug-bar --network`
+    Then STDOUT should be:
+      """
+      Plugin 'site-secrets' network deactivated.
+      Plugin 'debug-bar' network deactivated.
+      Success: Network deactivated 2 of 2 plugins.
+      """
+
+    When I run `wp plugin list --recently-active --field=name`
+    Then STDOUT should be a table containing rows:
+      | debug-bar    |
+      | site-secrets |
+
+  Scenario: For a MU site, use recently active plugin to activate plugins
+    Given a WP multisite install
+
+    When I run `wp plugin install site-secrets debug-bar --activate-network`
+    Then STDOUT should contain:
+      """
+      Plugin 'site-secrets' network activated.
+      """
+    And STDOUT should contain:
+      """
+      Plugin 'debug-bar' network activated.
+      """
+
+    When I run `wp plugin deactivate site-secrets debug-bar --network`
+    Then STDOUT should be:
+      """
+      Plugin 'site-secrets' network deactivated.
+      Plugin 'debug-bar' network deactivated.
+      Success: Network deactivated 2 of 2 plugins.
+      """
+
+    When I run `wp plugin activate $(wp plugin list --recently-active --field=name) --network`
+    Then STDOUT should contain:
+      """
+      Plugin 'site-secrets' network activated.
+      """
+    And STDOUT should contain:
+      """
+      Plugin 'debug-bar' network activated.
+      """

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -329,6 +329,18 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     $ wp plugin activate hello --network
 	 *     Plugin 'hello' network activated.
 	 *     Success: Network activated 1 of 1 plugins.
+	 *
+	 *     # Activate plugins that were recently active.
+	 *     $ wp plugin activate $(wp plugin list --recently-active --field=name)
+	 *     Plugin 'bbpress' activated.
+	 *     Plugin 'buddypress' activated.
+	 *     Success: Activated 2 of 2 plugins.
+	 *
+	 *     # Activate plugins that were recently active on a multisite.
+	 *     $ wp plugin activate $(wp plugin list --recently-active --field=name) --network
+	 *     Plugin 'bbpress' network activated.
+	 *     Plugin 'buddypress' network activated.
+	 *     Success: Activated 2 of 2 plugins.
 	 */
 	public function activate( $args, $assoc_args = array() ) {
 		$network_wide = Utils\get_flag_value( $assoc_args, 'network', false );
@@ -1370,6 +1382,10 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     | wordpress-importer | active       | 2023-04-28         |
 	 *     | local              |              |                    |
 	 *     +--------------------+--------------+--------------------+
+	 *
+	 *     # List recently active plugins on the site.
+	 *     $ wp plugin list --recently-active --field=name --format=json
+	 *     ["akismet","bbpress","buddypress"]
 	 *
 	 * @subcommand list
 	 */

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -718,6 +718,12 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			$auto_updates = [];
 		}
 
+		$recently_active = is_network_admin() ? get_site_option( 'recently_activated' ) : get_option( 'recently_activated' );
+
+		if ( false === $recently_active ) {
+			$recently_active = [];
+		}
+
 		foreach ( $this->get_all_plugins() as $file => $details ) {
 			$all_update_info = $this->get_update_info();
 			$update_info     = ( isset( $all_update_info->response[ $file ] ) && null !== $all_update_info->response[ $file ] ) ? (array) $all_update_info->response[ $file ] : null;
@@ -745,6 +751,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'tested_up_to'       => '',
 				'wporg_status'       => $wporg_info['status'],
 				'wporg_last_updated' => $wporg_info['last_updated'],
+				'recently_active'    => in_array( $file, array_keys( $recently_active ), true ),
 			];
 
 			if ( $this->check_headers['tested_up_to'] ) {
@@ -1305,6 +1312,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *
 	 * [--skip-update-check]
 	 * : If set, the plugin update check will be skipped.
+	 *
+	 * [--recently-active]
+	 * : If set, only recently active plugins will be shown and the status filter will be ignored.
 	 *
 	 * ## AVAILABLE FIELDS
 	 *

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -539,6 +539,15 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		$all_items = $this->get_all_items();
 
+		if ( false !== (bool) Utils\get_flag_value( $assoc_args, 'recently-active', false ) ) {
+			$all_items = array_filter(
+				$all_items,
+				function ( $value ) {
+					return isset( $value['recently_active'] ) && true === $value['recently_active'];
+				}
+			);
+		}
+
 		if ( ! is_array( $all_items ) ) {
 			WP_CLI::error( "No {$this->item_type}s found." );
 		}


### PR DESCRIPTION
Related: https://github.com/wp-cli/extension-command/issues/232

PR continued from https://github.com/wp-cli/extension-command/pull/383

```
wp plugin list --recently-active
```

This will give the list of recently active plugins.