### PR TITLE
Add `--force-check` flag to `wp plugin list` and `wp theme list`.

### DIFF
--- a/features/plugin-list.feature
+++ b/features/plugin-list.feature
@@ -58,7 +58,7 @@ Feature: List WordPress plugins
     When I try `wp plugin list --skip-update-check --force-check`
     Then STDERR should contain:
       """
-      Error: plugin updates cannot be both force-checked and skipped. Choose one.
+      Error: Plugin updates cannot be both force-checked and skipped. Choose one.
       """
     And STDOUT should be empty
     And the return code should be 1

--- a/features/plugin-list.feature
+++ b/features/plugin-list.feature
@@ -44,7 +44,7 @@ Feature: List WordPress plugins
       | hello-dolly  | inactive | available |
 
     # Repeating the same command again should produce the same results
-    When I run `wp plugin list --fields=name,status,update`
+    When I run the previous command again
     Then STDOUT should be a table containing rows:
       | name         | status   | update    |
       | hello-dolly  | inactive | available |

--- a/features/plugin-list.feature
+++ b/features/plugin-list.feature
@@ -1,0 +1,71 @@
+Feature: List WordPress plugins
+
+  Background:
+    Given a WP install
+    And I run `wp plugin uninstall --all`
+    And I run `wp plugin install hello-dolly`
+    And a setup.php file:
+      """
+      <?php
+      $plugin_transient = get_site_transient('update_plugins') ;
+      # manually set the version
+      $fake_version = '10.0.0';
+      $plugin_transient->no_update["hello-dolly/hello.php"]->new_version = $fake_version;
+      $return = set_site_transient( 'update_plugins', $plugin_transient );
+      """
+#    And a wp-content/mu-plugins/test-plugin-update.php file:
+#      """
+#      <?php
+#      /**
+#       * Plugin Name: Test Plugin Update
+#       * Description: Fakes installed plugin's data to verify plugin version mismatch
+#       * Author: WP-CLI tests
+#       */
+#
+#      add_filter( 'site_transient_update_plugins', function( $value ) {
+#          if ( ! is_object( $value ) ) {
+#              return $value;
+#          }
+#          $fake_version = '10.0.0';
+#
+#          unset( $value->response['hello-dolly/hello.php'] );
+#          $value->no_update['hello-dolly/hello.php']->new_version = $fake_version;
+#
+#          return $value;
+#      } );
+#      ?>
+#      """
+
+  Scenario: Refresh update_plugins transient when listing plugins with --force-check flag
+
+    # Listing the plugins will populate the transient in the database
+    When I run `wp plugin list`
+    Then STDOUT should not be empty
+    And save STDOUT as {PLUGIN_LIST_ORIGINAL_VERSIONS}
+
+    # Write a test value
+    When I run `wp eval-file setup.php`
+    Then STDOUT should be empty
+
+    # Get value of plugin transient
+    #When I run `wp option get _site_transient_update_plugins`
+    #Then STDOUT should be empty
+
+    # Run list again
+    When I run `wp plugin list`
+    Then STDOUT should be empty
+    And save STDOUT as {PLUGIN_LIST_FAKE_VERSIONS}
+
+    # TODO: compare {PLUGIN_LIST_ORIGINAL_VERSIONS} to {PLUGIN_LIST_FAKE_VERSIONS}
+    # expected result: they should be different
+
+    # Get value of plugin transient
+    When I run `wp option get _site_transient_update_plugins`
+    Then STDOUT should be empty
+
+    When I run `wp plugin list --force-check`
+    Then STDOUT should not be empty
+    And save STDOUT as {PLUGIN_LIST_FORCE_CHECK_VERSIONS}
+
+    # TODO: compare {PLUGIN_LIST_ORIGINAL_VERSIONS} to {PLUGIN_LIST_FORCE_CHECK_VERSIONS}
+    # expected result: they should be the same

--- a/features/plugin-list.feature
+++ b/features/plugin-list.feature
@@ -54,3 +54,11 @@ Feature: List WordPress plugins
     Then STDOUT should be a table containing rows:
       | name         | status   | update |
       | hello-dolly  | inactive | none   |
+
+    When I try `wp plugin list --skip-update-check --force-check`
+    Then STDERR should contain:
+      """
+      Error: plugin updates cannot be both force-checked and skipped. Choose one.
+      """
+    And STDOUT should be empty
+    And the return code should be 1

--- a/features/theme-list.feature
+++ b/features/theme-list.feature
@@ -56,7 +56,7 @@ Feature: List WordPress themes
     When I try `wp theme list --skip-update-check --force-check`
     Then STDERR should contain:
       """
-      Error: theme updates cannot be both force-checked and skipped. Choose one.
+      Error: Theme updates cannot be both force-checked and skipped. Choose one.
       """
     And STDOUT should be empty
     And the return code should be 1

--- a/features/theme-list.feature
+++ b/features/theme-list.feature
@@ -3,32 +3,30 @@ Feature: List WordPress themes
   Scenario: Refresh update_themes transient when listing themes with --force-check flag
     Given a WP install
     And I run `wp theme delete --all --force`
-    And I run `wp theme install --force twentytwentyfour --version=1.1`
+    And I run `wp theme install --force twentytwelve --version=4.2`
     And a update-transient.php file:
       """
       <?php
       $transient = get_site_transient( 'update_themes' );
-      $transient->response['twentytwentyfour'] = (object) array(
-        'theme'        => 'twentytwentyfour',
+      $transient->response['twentytwelve'] = (object) array(
+        'theme'        => 'twentytwelve',
         'new_version'  => '100.0.0',
-        'url'          => 'https://wordpress.org/themes/twentytwentyfour/',
-        'package'      => 'https://downloads.wordpress.org/theme/twentytwentyfour.100.zip',
-        'requires'     => '6.4',
-        'requires_php' => '7.0'
+        'url'          => 'https://wordpress.org/themes/twentytwelve/',
+        'package'      => 'https://downloads.wordpress.org/theme/twentytwelve.100.zip'
       );
       $transient->checked = array(
-        'twentytwentyfour' => '1.1',
+        'twentytwelve' => '4.2',
       );
-      unset( $transient->no_update['twentytwentyfour'] );
+      unset( $transient->no_update['twentytwelve'] );
       set_site_transient( 'update_themes', $transient );
       WP_CLI::success( 'Transient updated.' );
       """
 
     # Populates the initial transient in the database
-    When I run `wp theme list --fields=name,status,update`
+    When I run `wp theme list --fields=name,update`
     Then STDOUT should be a table containing rows:
-      | name              | status   | update |
-      | twentytwentyfour  | active   | none   |
+      | name              | update |
+      | twentytwelve      | none   |
 
     # Modify the transient in the database to simulate an update
     When I run `wp eval-file update-transient.php`
@@ -38,22 +36,22 @@ Feature: List WordPress themes
       """
 
     # Verify the fake transient value produces the expected output
-    When I run `wp theme list --fields=name,status,update`
+    When I run `wp theme list --fields=name,update`
     Then STDOUT should be a table containing rows:
-      | name              | status   | update    |
-      | twentytwentyfour  | active   | available |
+      | name              | update    |
+      | twentytwelve      | available |
 
     # Repeating the same command again should produce the same results
-    When I run `wp theme list --fields=name,status,update`
+    When I run the previous command again
     Then STDOUT should be a table containing rows:
-      | name              | status   | update    |
-      | twentytwentyfour  | active   | available |
+      | name              | update    |
+      | twentytwelve      | available |
 
     # Using the --force-check flag should refresh the transient back to the original value
-    When I run `wp theme list --fields=name,status,update --force-check`
+    When I run `wp theme list --fields=name,update --force-check`
     Then STDOUT should be a table containing rows:
-      | name              | status   | update |
-      | twentytwentyfour  | active   | none   |
+      | name              | update |
+      | twentytwelve      | none   |
 
     When I try `wp theme list --skip-update-check --force-check`
     Then STDERR should contain:

--- a/features/theme-list.feature
+++ b/features/theme-list.feature
@@ -1,0 +1,27 @@
+Feature: List WordPress themes
+
+  Background:
+    Given a WP install
+    And a setup.php file:
+      """
+      <?php
+      $theme_transient = new stdClass;
+      $theme_transient->last_checked = time();
+      $theme_transient->checked = [];
+      $theme_transient->response = [];
+      $theme_transient->no_update = [];
+      $theme_transient->translations = [];
+      $return = update_option( '_site_transient_update_themes', $theme_transient );
+      """
+    And I run `wp transient delete update_themes --network`
+
+  Scenario: Refresh update_themes transient when listing themes with --force-check flag
+
+    # Listing the themes will populate the transient in the database
+    When I run `wp theme list`
+    Then STDOUT should not be empty
+
+    When I run `wp transient set update_themes test_value --network`
+    And I run `wp theme list --force-check`
+
+    Then STDOUT should be empty

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1327,7 +1327,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *
 	 * [--force-check]
 	 * : Bypass the transient cache and force a fresh update check.
-     *
+	 *
 	 * [--recently-active]
 	 * : If set, only recently active plugins will be shown and the status filter will be ignored.
 	 *

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1325,6 +1325,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * [--skip-update-check]
 	 * : If set, the plugin update check will be skipped.
 	 *
+	 * [--force-check]
+	 * : Bypass the transient cache and force a fresh update check.
+     *
 	 * [--recently-active]
 	 * : If set, only recently active plugins will be shown and the status filter will be ignored.
 	 *

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -857,6 +857,9 @@ class Theme_Command extends CommandWithUpgrade {
 	 * [--skip-update-check]
 	 * : If set, the theme update check will be skipped.
 	 *
+	 * [--force-check]
+	 * : Bypass the transient cache and force a fresh update check.
+	 *
 	 * ## AVAILABLE FIELDS
 	 *
 	 * These fields will be displayed by default for each theme:

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -534,7 +534,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		// If `--force-check` and `--skip-update-check` flags are both present, abort.
 		if ( true === (bool) Utils\get_flag_value( $assoc_args, 'force-check', false ) && true === (bool) Utils\get_flag_value( $assoc_args, 'skip-update-check', false ) ) {
-			WP_CLI::error( "{$this->item_type} updates cannot be both force-checked and skipped. Choose one." );
+			WP_CLI::error( ucfirst( "{$this->item_type} updates cannot be both force-checked and skipped. Choose one." ) );
 		}
 
 		// If `--force-check` flag is present, delete the upgrade transient.

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -532,6 +532,11 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	// phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- Whitelisting to provide backward compatibility to classes possibly extending this class.
 	protected function _list( $_, $assoc_args ) {
 
+		// If `--force-check` and `--skip-update-check` flags are both present, abort.
+		if ( true === (bool) Utils\get_flag_value( $assoc_args, 'force-check', false ) and true === (bool) Utils\get_flag_value( $assoc_args, 'skip-update-check', false ) ) {
+			WP_CLI::error("{$this->item_type} updates cannot be both force-checked and skipped. Choose one.");
+		}
+
 		// If `--force-check` flag is present, delete the upgrade transient.
 		if ( true === (bool) Utils\get_flag_value( $assoc_args, 'force-check', false ) ) {
 			delete_site_transient( $this->upgrade_transient );

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -532,9 +532,9 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	// phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- Whitelisting to provide backward compatibility to classes possibly extending this class.
 	protected function _list( $_, $assoc_args ) {
 
-		// If `--force-check` flag is present, delete the ${item_type} transient.
+		// If `--force-check` flag is present, delete the upgrade transient.
 		if ( true === (bool) Utils\get_flag_value( $assoc_args, 'force-check', false ) ) {
-			delete_site_transient( $this->item_type . 's' );
+			delete_site_transient( $this->upgrade_transient );
 		}
 
 		// Force WordPress to check for updates if `--skip-update-check` is not passed.

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -532,6 +532,11 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	// phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- Whitelisting to provide backward compatibility to classes possibly extending this class.
 	protected function _list( $_, $assoc_args ) {
 
+		// If `--force-check` flag is present, delete the ${item_type} transient.
+		if ( true === (bool) Utils\get_flag_value( $assoc_args, 'force-check', false ) ) {
+			delete_site_transient( $this->item_type . 's' );
+		}
+
 		// Force WordPress to check for updates if `--skip-update-check` is not passed.
 		if ( false === (bool) Utils\get_flag_value( $assoc_args, 'skip-update-check', false ) ) {
 			call_user_func( $this->upgrade_refresh );

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -533,8 +533,8 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	protected function _list( $_, $assoc_args ) {
 
 		// If `--force-check` and `--skip-update-check` flags are both present, abort.
-		if ( true === (bool) Utils\get_flag_value( $assoc_args, 'force-check', false ) and true === (bool) Utils\get_flag_value( $assoc_args, 'skip-update-check', false ) ) {
-			WP_CLI::error("{$this->item_type} updates cannot be both force-checked and skipped. Choose one.");
+		if ( true === (bool) Utils\get_flag_value( $assoc_args, 'force-check', false ) && true === (bool) Utils\get_flag_value( $assoc_args, 'skip-update-check', false ) ) {
+			WP_CLI::error( "{$this->item_type} updates cannot be both force-checked and skipped. Choose one." );
 		}
 
 		// If `--force-check` flag is present, delete the upgrade transient.


### PR DESCRIPTION
Hi @danielbachhuber,

In the process of updating my fork, I somehow accidentally closed [the existing pull request](https://github.com/wp-cli/extension-command/pull/399) for this feature.

Here's the code and tests. Please let me know if you have any feedback!

Saul