### PR TITLE
Require `wp-cli/wp-cli` v2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "composer/semver": "^1.4 || ^2 || ^3",
-        "wp-cli/wp-cli": "^2.10"
+        "wp-cli/wp-cli": "^2.12"
     },
     "require-dev": {
         "wp-cli/cache-command": "^2.0",


### PR DESCRIPTION
For improved PHP 8.4 compatibility.