### PR TITLE
Check WordPress and PHP requirements before installing a theme or plugin

### DIFF
--- a/features/plugin-auto-updates-disable.feature
+++ b/features/plugin-auto-updates-disable.feature
@@ -2,7 +2,7 @@ Feature: Disable auto-updates for WordPress plugins
 
   Background:
     Given a WP install
-    And I run `wp plugin install duplicate-post`
+    And I run `wp plugin install duplicate-post --ignore-requirements`
     And I run `wp plugin auto-updates enable --all`
 
   @require-wp-5.5

--- a/features/plugin-auto-updates-enable.feature
+++ b/features/plugin-auto-updates-enable.feature
@@ -2,7 +2,7 @@ Feature: Enable auto-updates for WordPress plugins
 
   Background:
     Given a WP install
-    And I run `wp plugin install duplicate-post`
+    And I run `wp plugin install duplicate-post --ignore-requirements`
 
   @require-wp-5.5
   Scenario: Show an error if required params are missing

--- a/features/plugin-auto-updates-status.feature
+++ b/features/plugin-auto-updates-status.feature
@@ -2,7 +2,7 @@ Feature: Show the status of auto-updates for WordPress plugins
 
   Background:
     Given a WP install
-    And I run `wp plugin install duplicate-post`
+    And I run `wp plugin install duplicate-post --ignore-requirements`
 
   @require-wp-5.5
   Scenario: Show an error if required params are missing

--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -238,6 +238,7 @@ Feature: Install WordPress plugins
     Success: Plugin already installed.
     """
 
+  @require-php-7
   Scenario: Can't install plugin that requires a newer version of WordPress
     Given a WP install
 

--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -237,3 +237,35 @@ Feature: Install WordPress plugins
     Plugin 'site-secrets' activated.
     Success: Plugin already installed.
     """
+
+  Scenario: Can't install plugin that requires a newer version of WordPress
+    Given a WP install
+
+    When I run `wp core download --version=6.4 --force`
+    And I run `rm -r wp-content/themes/*`
+
+    And I try `wp plugin install wp-super-cache`
+    Then STDERR should contain:
+    """
+    Warning: wp-super-cache: This plugin does not work with your version of WordPress
+    """
+
+    And STDERR should contain:
+    """
+    Error: No plugins installed.
+    """
+
+  @less-than-php-7.4
+  Scenario: Can't install plugin that requires a newer version of PHP
+    Given a WP install
+
+    And I try `wp plugin install contact-form-7`
+    Then STDERR should contain:
+    """
+    Warning: contact-form-7: This plugin does not work with your version of PHP
+    """
+
+    And STDERR should contain:
+    """
+    Error: No plugins installed.
+    """

--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -255,7 +255,7 @@ Feature: Install WordPress plugins
     Error: No plugins installed.
     """
 
-  @less-than-php-7.4
+  @less-than-php-7.4 @require-wp-6.6
   Scenario: Can't install plugin that requires a newer version of PHP
     Given a WP install
 

--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -171,7 +171,7 @@ Feature: Install WordPress plugins
     When I run `rm wp-content/plugins/akismet/akismet.php`
     Then the return code should be 0
 
-    When I try `wp plugin install akismet`
+    When I try `wp plugin install akismet --ignore-requirements`
     Then STDERR should contain:
       """
       Warning: Destination folder already exists. "{WORKING_DIR}/wp-content/plugins/akismet/"

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -329,7 +329,7 @@ Feature: Manage WordPress plugins
     When I run `wp plugin activate akismet hello`
     Then STDOUT should not be empty
 
-    When I run `wp plugin install wordpress-importer`
+    When I run `wp plugin install wordpress-importer --ignore-requirements`
     Then STDOUT should not be empty
 
     When I run `wp plugin activate network-only`
@@ -373,6 +373,8 @@ Feature: Manage WordPress plugins
       | name               | status   | update   |
       | wordpress-importer | inactive | none     |
 
+  # WordPress Importer requires WP 5.2.
+  @require-wp-5.2
   Scenario: Install a plugin when directory doesn't yet exist
     Given a WP install
 
@@ -448,6 +450,8 @@ Feature: Manage WordPress plugins
       must-use
       """
 
+  # WordPress Importer requires WP 5.2.
+  @require-wp-5.2
   Scenario: Deactivate and uninstall a plugin, part one
     Given a WP install
     And these installed and active plugins:
@@ -472,6 +476,8 @@ Feature: Manage WordPress plugins
     And STDOUT should be empty
     And the return code should be 1
 
+  # WordPress Importer requires WP 5.2.
+  @require-wp-5.2
   Scenario: Deactivate and uninstall a plugin, part two
     Given a WP install
     And these installed and active plugins:

--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -125,3 +125,35 @@ Feature: Install WordPress themes
       """
       twentyeleven
       """
+
+  Scenario: Can't install theme that requires a newer version of WordPress
+    Given a WP install
+
+    When I run `wp core download --version=6.4 --force`
+    And I run `rm -r wp-content/themes/*`
+
+    And I try `wp theme install twentytwentyfive`
+    Then STDERR should contain:
+    """
+    Warning: twentytwentyfive: This theme does not work with your version of WordPress.
+    """
+
+    And STDERR should contain:
+    """
+    Error: No themes installed.
+    """
+
+  @less-than-php-7.4
+  Scenario: Can't install theme that requires a newer version of PHP
+    Given a WP install
+
+    And I try `wp theme install oceanwp`
+    Then STDERR should contain:
+    """
+    Warning: oceanwp: This theme does not work with your version of PHP.
+    """
+
+    And STDERR should contain:
+    """
+    Error: No themes installed.
+    """

--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -143,7 +143,7 @@ Feature: Install WordPress themes
     Error: No themes installed.
     """
 
-  @less-than-php-7.4
+  @less-than-php-7.4 @require-wp-5.6
   Scenario: Can't install theme that requires a newer version of PHP
     Given a WP install
 

--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -126,6 +126,7 @@ Feature: Install WordPress themes
       twentyeleven
       """
 
+  @require-php-7
   Scenario: Can't install theme that requires a newer version of WordPress
     Given a WP install
 

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -593,7 +593,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			return $api;
 		}
 
-		if ( isset( $assoc_args['version'] ) ) {
+		if ( isset( $assoc_args['version'] ) || isset( $assoc_args['ignore-requirements'] ) ) {
 			self::alter_api_response( $api, $assoc_args['version'] );
 		} else {
 			$requires_php = isset( $api->requires_php ) ? $api->requires_php : null;
@@ -914,6 +914,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * [--force]
 	 * : If set, the command will overwrite any installed version of the plugin, without prompting
 	 * for confirmation.
+	 *
+	 * [--ignore-requirements]
+	 * :If set, the command will install the plugin while ignoring any requirements specified by the plugin authors.
 	 *
 	 * [--activate]
 	 * : If set, the plugin will be activated immediately after install.

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -582,6 +582,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	}
 
 	protected function install_from_repo( $slug, $assoc_args ) {
+		global $wp_version;
 		$api = plugins_api( 'plugin_information', array( 'slug' => $slug ) );
 
 		if ( is_wp_error( $api ) ) {
@@ -594,8 +595,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			$requires_php = isset( $api->requires_php ) ? $api->requires_php : null;
 			$requires_wp  = isset( $api->requires ) ? $api->requires : null;
 
-			$compatible_php = is_php_version_compatible( $requires_php );
-			$compatible_wp  = is_wp_version_compatible( $requires_wp );
+			$compatible_php = empty( $requires_php ) || version_compare( PHP_VERSION, $requires_php, '>=' );
+			$compatible_wp  = empty( $requires_wp ) || version_compare( $wp_version, $requires_wp, '>=' );
 
 			if ( ! $compatible_wp ) {
 				return new WP_Error( 'requirements_not_met', "This plugin does not work with your version of WordPress. Minimum WordPress requirement is $requires_wp" );

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -590,6 +590,20 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 		if ( isset( $assoc_args['version'] ) ) {
 			self::alter_api_response( $api, $assoc_args['version'] );
+		} else {
+			$requires_php = isset( $api->requires_php ) ? $api->requires_php : null;
+			$requires_wp  = isset( $api->requires ) ? $api->requires : null;
+
+			$compatible_php = is_php_version_compatible( $requires_php );
+			$compatible_wp  = is_wp_version_compatible( $requires_wp );
+
+			if ( ! $compatible_wp ) {
+				return new WP_Error( 'requirements_not_met', "This plugin does not work with your version of WordPress. Minimum WordPress requirement is $requires_wp" );
+			}
+
+			if ( ! $compatible_php ) {
+				return new WP_Error( 'requirements_not_met', "This plugin does not work with your version of PHP. Minimum PHP required is $compatible_php" );
+			}
 		}
 
 		$status = install_plugin_install_status( $api );

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -583,6 +583,10 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 	protected function install_from_repo( $slug, $assoc_args ) {
 		global $wp_version;
+		// Extract the major WordPress version (e.g., "6.3") from the full version string
+		list($wp_core_version) = explode( '-', $wp_version );
+		$wp_core_version       = implode( '.', array_slice( explode( '.', $wp_core_version ), 0, 2 ) );
+
 		$api = plugins_api( 'plugin_information', array( 'slug' => $slug ) );
 
 		if ( is_wp_error( $api ) ) {
@@ -596,7 +600,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			$requires_wp  = isset( $api->requires ) ? $api->requires : null;
 
 			$compatible_php = empty( $requires_php ) || version_compare( PHP_VERSION, $requires_php, '>=' );
-			$compatible_wp  = empty( $requires_wp ) || version_compare( $wp_version, $requires_wp, '>=' );
+			$compatible_wp  = empty( $requires_wp ) || version_compare( $wp_core_version, $requires_wp, '>=' );
 
 			if ( ! $compatible_wp ) {
 				return new WP_Error( 'requirements_not_met', "This plugin does not work with your version of WordPress. Minimum WordPress requirement is $requires_wp" );

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -593,7 +593,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			return $api;
 		}
 
-		if ( isset( $assoc_args['version'] ) || isset( $assoc_args['ignore-requirements'] ) ) {
+		if ( isset( $assoc_args['version'] ) || Utils\get_flag_value( $assoc_args, 'ignore-requirements' ) ) {
 			self::alter_api_response( $api, $assoc_args['version'] );
 		} else {
 			$requires_php = isset( $api->requires_php ) ? $api->requires_php : null;
@@ -916,7 +916,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * for confirmation.
 	 *
 	 * [--ignore-requirements]
-	 * :If set, the command will install the plugin while ignoring any requirements specified by the plugin authors.
+	 * :If set, the command will install the plugin while ignoring any WordPress or PHP version requirements
+	 * specified by the plugin authors.
 	 *
 	 * [--activate]
 	 * : If set, the plugin will be activated immediately after install.

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -593,9 +593,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			return $api;
 		}
 
-		if ( isset( $assoc_args['version'] ) || Utils\get_flag_value( $assoc_args, 'ignore-requirements' ) ) {
+		if ( isset( $assoc_args['version'] ) ) {
 			self::alter_api_response( $api, $assoc_args['version'] );
-		} else {
+		} elseif ( ! Utils\get_flag_value( $assoc_args, 'ignore-requirements', false ) ) {
 			$requires_php = isset( $api->requires_php ) ? $api->requires_php : null;
 			$requires_wp  = isset( $api->requires ) ? $api->requires : null;
 

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -403,6 +403,20 @@ class Theme_Command extends CommandWithUpgrade {
 
 		if ( isset( $assoc_args['version'] ) ) {
 			self::alter_api_response( $api, $assoc_args['version'] );
+		} else {
+			$requires_php = isset( $api->requires_php ) ? $api->requires_php : null;
+			$requires_wp  = isset( $api->requires ) ? $api->requires : null;
+
+			$compatible_php = is_php_version_compatible( $requires_php );
+			$compatible_wp  = is_wp_version_compatible( $requires_wp );
+
+			if ( ! $compatible_wp ) {
+				return new WP_Error( 'requirements_not_met', "This theme does not work with your version of WordPress. Minimum WordPress requirement is $requires_wp" );
+			}
+
+			if ( ! $compatible_php ) {
+				return new WP_Error( 'requirements_not_met', "This theme does not work with your version of PHP. Minimum PHP required is $requires_php" );
+			}
 		}
 
 		if ( ! Utils\get_flag_value( $assoc_args, 'force' ) ) {

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -395,6 +395,7 @@ class Theme_Command extends CommandWithUpgrade {
 	}
 
 	protected function install_from_repo( $slug, $assoc_args ) {
+		global $wp_version;
 		$api = themes_api( 'theme_information', array( 'slug' => $slug ) );
 
 		if ( is_wp_error( $api ) ) {
@@ -407,8 +408,8 @@ class Theme_Command extends CommandWithUpgrade {
 			$requires_php = isset( $api->requires_php ) ? $api->requires_php : null;
 			$requires_wp  = isset( $api->requires ) ? $api->requires : null;
 
-			$compatible_php = is_php_version_compatible( $requires_php );
-			$compatible_wp  = is_wp_version_compatible( $requires_wp );
+			$compatible_php = empty( $requires_php ) || version_compare( PHP_VERSION, $requires_php, '>=' );
+			$compatible_wp  = empty( $requires_wp ) || version_compare( $wp_version, $requires_wp, '>=' );
 
 			if ( ! $compatible_wp ) {
 				return new WP_Error( 'requirements_not_met', "This theme does not work with your version of WordPress. Minimum WordPress requirement is $requires_wp" );

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -406,9 +406,9 @@ class Theme_Command extends CommandWithUpgrade {
 			return $api;
 		}
 
-		if ( isset( $assoc_args['version'] ) || Utils\get_flag_value( $assoc_args, 'ignore-requirements' ) ) {
+		if ( isset( $assoc_args['version'] ) ) {
 			self::alter_api_response( $api, $assoc_args['version'] );
-		} else {
+		} elseif ( ! Utils\get_flag_value( $assoc_args, 'ignore-requirements', false ) ) {
 			$requires_php = isset( $api->requires_php ) ? $api->requires_php : null;
 			$requires_wp  = isset( $api->requires ) ? $api->requires : null;
 

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -406,7 +406,7 @@ class Theme_Command extends CommandWithUpgrade {
 			return $api;
 		}
 
-		if ( isset( $assoc_args['version'] ) ) {
+		if ( isset( $assoc_args['version'] ) || isset( $assoc_args['ignore-requirements'] ) ) {
 			self::alter_api_response( $api, $assoc_args['version'] );
 		} else {
 			$requires_php = isset( $api->requires_php ) ? $api->requires_php : null;
@@ -480,6 +480,9 @@ class Theme_Command extends CommandWithUpgrade {
 	 * [--force]
 	 * : If set, the command will overwrite any installed version of the theme, without prompting
 	 * for confirmation.
+	 *
+	 * [--ignore-requirements]
+	 * : If set, the command will install the theme while ignoring any requirements specified by the theme authors.
 	 *
 	 * [--activate]
 	 * : If set, the theme will be activated immediately after install.

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -396,6 +396,10 @@ class Theme_Command extends CommandWithUpgrade {
 
 	protected function install_from_repo( $slug, $assoc_args ) {
 		global $wp_version;
+		// Extract the major WordPress version (e.g., "6.3") from the full version string
+		list($wp_core_version) = explode( '-', $wp_version );
+		$wp_core_version       = implode( '.', array_slice( explode( '.', $wp_core_version ), 0, 2 ) );
+
 		$api = themes_api( 'theme_information', array( 'slug' => $slug ) );
 
 		if ( is_wp_error( $api ) ) {
@@ -409,7 +413,7 @@ class Theme_Command extends CommandWithUpgrade {
 			$requires_wp  = isset( $api->requires ) ? $api->requires : null;
 
 			$compatible_php = empty( $requires_php ) || version_compare( PHP_VERSION, $requires_php, '>=' );
-			$compatible_wp  = empty( $requires_wp ) || version_compare( $wp_version, $requires_wp, '>=' );
+			$compatible_wp  = empty( $requires_wp ) || version_compare( $wp_core_version, $requires_wp, '>=' );
 
 			if ( ! $compatible_wp ) {
 				return new WP_Error( 'requirements_not_met', "This theme does not work with your version of WordPress. Minimum WordPress requirement is $requires_wp" );

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -406,7 +406,7 @@ class Theme_Command extends CommandWithUpgrade {
 			return $api;
 		}
 
-		if ( isset( $assoc_args['version'] ) || isset( $assoc_args['ignore-requirements'] ) ) {
+		if ( isset( $assoc_args['version'] ) || Utils\get_flag_value( $assoc_args, 'ignore-requirements' ) ) {
 			self::alter_api_response( $api, $assoc_args['version'] );
 		} else {
 			$requires_php = isset( $api->requires_php ) ? $api->requires_php : null;
@@ -482,7 +482,8 @@ class Theme_Command extends CommandWithUpgrade {
 	 * for confirmation.
 	 *
 	 * [--ignore-requirements]
-	 * : If set, the command will install the theme while ignoring any requirements specified by the theme authors.
+	 * : If set, the command will install the theme while ignoring any WordPress or PHP version requirements
+	 * specified by the theme authors.
 	 *
 	 * [--activate]
 	 * : If set, the theme will be activated immediately after install.


### PR DESCRIPTION
This matches the behavior of WordPress core which will refuse to install a plugin if the local copy of WordPress or PHP don't meet the minimum requirements for the most recent version as listed by the plugin authors.

Unfortunately the api is limited and only provides these requirement details for the most recent version, so it isn't possible to find an older version that might work. As a compromise, this code doesn't check requirements if a user provides a specific `--version` since we can't know the requirements for anything other than the latest version and assume if somebody specifies a version they know it will work or want to try anyway.