### PR TITLE
Support requires and requires_php in plugin/theme list and update command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "wp-cli/entity-command": "^1.3 || ^2",
         "wp-cli/language-command": "^2.0",
         "wp-cli/scaffold-command": "^1.2 || ^2",
-        "wp-cli/wp-cli-tests": "^4"
+        "wp-cli/wp-cli-tests": "^4.3.7"
     },
     "config": {
         "process-timeout": 7200,

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -811,6 +811,7 @@ Feature: Manage WordPress plugins
       5.5
       """
 
+  @require-wp-4.0
   Scenario: Show plugin update as unavailable if it doesn't meet WordPress requirements
     Given a WP install
     And a wp-content/plugins/example/example.php file:
@@ -857,6 +858,7 @@ Feature: Manage WordPress plugins
       Warning: example: This update requires WordPress version 100
       """
 
+ @require-wp-4.0
  Scenario: Show plugin update as unavailable if it doesn't meet PHP requirements
     Given a WP install
     And a wp-content/plugins/example/example.php file:

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -836,7 +836,7 @@ Feature: Manage WordPress plugins
     When I try `wp plugin update wp-super-cache`
     Then STDERR should contain:
       """
-      Warning: wp-super-cache: Requires a newer version of WordPress
+      Warning: wp-super-cache: This update requires WordPress version
       """
 
   @less-than-php-8.0 @require-wp-5.6
@@ -862,6 +862,6 @@ Feature: Manage WordPress plugins
     When I try `wp plugin update edit-flow`
     Then STDERR should contain:
       """
-      Warning: edit-flow: Requires a newer version of PHP
+      Warning: edit-flow: This update requires PHP version
       """
 

--- a/features/theme-update.feature
+++ b/features/theme-update.feature
@@ -32,6 +32,7 @@ Feature: Update WordPress themes
       | name         | version   |
       | twentytwelve | 4.0       |
 
+  @require-wp-4.5
   Scenario: Not giving a slug on update should throw an error unless --all given
     Given a WP install
     And I run `wp theme path`

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -210,7 +210,7 @@ Feature: Manage WordPress themes
   Scenario: Flag `--skip-update-check` skips update check when running `wp theme list`
     Given a WP install
 
-    When I run `wp theme install astra --version=1.0.0`
+    When I run `wp theme install twentythirteen --version=1.1`
     Then STDOUT should contain:
       """
       Theme installed successfully.
@@ -218,8 +218,8 @@ Feature: Manage WordPress themes
 
     When I run `wp theme list --fields=name,status,update`
     Then STDOUT should be a table containing rows:
-      | name  | status   | update    |
-      | astra | inactive | available |
+      | name           | status   | update    |
+      | twentythirteen | inactive | available |
 
     When I run `wp transient delete update_themes --network`
     Then STDOUT should be:
@@ -229,8 +229,8 @@ Feature: Manage WordPress themes
 
     When I run `wp theme list --fields=name,status,update --skip-update-check`
     Then STDOUT should be a table containing rows:
-      | name  | status   | update |
-      | astra | inactive | none   |
+      | name           | status   | update |
+      | twentythirteen | inactive | none   |
 
   Scenario: Install a theme when the theme directory doesn't yet exist
     Given a WP install

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -646,5 +646,5 @@ Feature: Manage WordPress themes
     When I try `wp theme update kadence`
     Then STDERR should contain:
       """
-      Warning: kadence: Requires a newer version of WordPress
+      Warning: kadence: This update requires WordPress version
       """

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -207,19 +207,20 @@ Feature: Manage WordPress themes
     And STDOUT should be empty
     And the return code should be 0
 
+  @require-wp-5.3
   Scenario: Flag `--skip-update-check` skips update check when running `wp theme list`
     Given a WP install
 
-    When I run `wp theme install twentyten --version=4.0`
+    When I run `wp theme install astra --version=1.0.0`
     Then STDOUT should contain:
       """
-      Installed 1 of 1 themes
+      Theme installed successfully.
       """
 
     When I run `wp theme list --fields=name,status,update`
     Then STDOUT should be a table containing rows:
       | name      | status   | update    |
-      | twentyten | inactive | available |
+      | astra     | inactive | available |
 
     When I run `wp transient delete update_themes --network`
     Then STDOUT should be:
@@ -230,7 +231,7 @@ Feature: Manage WordPress themes
     When I run `wp theme list --fields=name,status,update --skip-update-check`
     Then STDOUT should be a table containing rows:
       | name      | status   | update |
-      | twentyten | inactive | none   |
+      | astra     | inactive | none   |
 
   Scenario: Install a theme when the theme directory doesn't yet exist
     Given a WP install

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -210,7 +210,7 @@ Feature: Manage WordPress themes
   Scenario: Flag `--skip-update-check` skips update check when running `wp theme list`
     Given a WP install
 
-    When I run `wp theme install twentythirteen --version=1.1 --force`
+    When I run `wp theme install twentyten --version=4.0`
     Then STDOUT should contain:
       """
       Installed 1 of 1 themes
@@ -218,8 +218,8 @@ Feature: Manage WordPress themes
 
     When I run `wp theme list --fields=name,status,update`
     Then STDOUT should be a table containing rows:
-      | name           | status   | update    |
-      | twentythirteen | inactive | available |
+      | name      | status   | update    |
+      | twentyten | inactive | available |
 
     When I run `wp transient delete update_themes --network`
     Then STDOUT should be:
@@ -229,8 +229,8 @@ Feature: Manage WordPress themes
 
     When I run `wp theme list --fields=name,status,update --skip-update-check`
     Then STDOUT should be a table containing rows:
-      | name           | status   | update |
-      | twentythirteen | inactive | none   |
+      | name      | status   | update |
+      | twentyten | inactive | none   |
 
   Scenario: Install a theme when the theme directory doesn't yet exist
     Given a WP install
@@ -284,6 +284,7 @@ Feature: Manage WordPress themes
       Theme updated successfully.
       """
 
+  @require-wp-5.7
   Scenario: Enabling and disabling a theme
   	Given a WP multisite install
     And I run `wp theme install moina`
@@ -379,6 +380,7 @@ Feature: Manage WordPress themes
     And STDOUT should be empty
     And the return code should be 1
 
+  @require-wp-5.7
   Scenario: Install and attempt to activate a child theme without its parent
     Given a WP install
     And I run `wp theme install moina-blog`
@@ -392,6 +394,7 @@ Feature: Manage WordPress themes
     And STDOUT should be empty
     And the return code should be 1
 
+  @require-wp-5.7
   Scenario: List an active theme with its parent
     Given a WP install
     And I run `wp theme install moina`
@@ -470,6 +473,7 @@ Feature: Manage WordPress themes
       twentytwelve,1.0,{UPDATE_VERSION},Updated
       """
 
+  @require-wp-5.7
   Scenario: Automatically install parent theme for a child theme
     Given a WP install
 
@@ -579,7 +583,7 @@ Feature: Manage WordPress themes
       Error: Parameter errors:
        Invalid value specified for 'status' (Filter the output by theme status.)
       """
-
+  @require-wp-5.7
   Scenario: Parent theme is active when its child is active
     Given a WP install
     And I run `wp theme delete --all --force`
@@ -621,7 +625,6 @@ Feature: Manage WordPress themes
       | auto_update          |
       | on                   |
 
-  @require-php-7
   Scenario: Show theme update as unavailable if it doesn't meet WordPress requirements
     Given a WP install
     And a wp-content/themes/example/style.css file:

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -210,10 +210,10 @@ Feature: Manage WordPress themes
   Scenario: Flag `--skip-update-check` skips update check when running `wp theme list`
     Given a WP install
 
-    When I run `wp theme install twentythirteen --version=1.1`
+    When I run `wp theme install twentythirteen --version=1.1 --force`
     Then STDOUT should contain:
       """
-      Theme installed successfully.
+      Installed 1 of 1 themes
       """
 
     When I run `wp theme list --fields=name,status,update`

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -55,10 +55,14 @@ Feature: Manage WordPress themes and plugins
     Then STDOUT should not be empty
     And save STDOUT as {UPDATE_VERSION}
 
-    When I run `wp <type> list`
+    When I run `wp <type> list --name=<item> --field=update`
+    Then STDOUT should not be empty
+    And save STDOUT as {UPDATE}
+
+    When I run `wp <type> list --fields=name,status,update,version,update_version,auto_update`
     Then STDOUT should be a table containing rows:
-      | name   | status   | update    | version   | update_version   | auto_update |
-      | <item> | inactive | available | <version> | {UPDATE_VERSION} | off         |
+      | name   | status   | update    | version    | update_version   | auto_update |
+      | <item> | inactive | {UPDATE}  | <version>  | {UPDATE_VERSION} | off         |
 
     When I run `wp <type> list --field=name`
     Then STDOUT should contain:

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -3,6 +3,7 @@ Feature: Manage WordPress themes and plugins
   Background:
     Given an empty cache
 
+  @require-wp-4.5
   Scenario Outline: Installing, upgrading and deleting a theme or plugin
     Given a WP install
     And I run `wp <type> path`
@@ -208,5 +209,5 @@ Feature: Manage WordPress themes and plugins
 
     Examples:
       | type   | type_name | item                    | item_title              | version | zip_file                                                               | file_to_check                                                     |
-      | theme  | Theme     | twentyten                      | Twenty Ten                      | 4.0   | https://wordpress.org/themes/download/twentyten.4.0.zip                     | {CONTENT_DIR}/twentyten/style.css                                        |
+      | theme  | Theme     | moina                      | Moina                      | 1.1.2   | https://wordpress.org/themes/download/moina.1.1.2.zip                     | {CONTENT_DIR}/moina/style.css                                        |
       | plugin | Plugin    | category-checklist-tree | Category Checklist Tree | 1.2     | https://downloads.wordpress.org/plugin/category-checklist-tree.1.2.zip | {CONTENT_DIR}/category-checklist-tree/category-checklist-tree.php |

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -55,14 +55,10 @@ Feature: Manage WordPress themes and plugins
     Then STDOUT should not be empty
     And save STDOUT as {UPDATE_VERSION}
 
-    When I run `wp <type> list --name=<item> --field=update`
-    Then STDOUT should not be empty
-    And save STDOUT as {UPDATE}
-
-    When I run `wp <type> list --fields=name,status,update,version,update_version,auto_update`
+    When I run `wp <type> list`
     Then STDOUT should be a table containing rows:
-      | name   | status   | update    | version    | update_version   | auto_update |
-      | <item> | inactive | {UPDATE}  | <version>  | {UPDATE_VERSION} | off         |
+      | name   | status   | update    | version   | update_version   | auto_update |
+      | <item> | inactive | available | <version> | {UPDATE_VERSION} | off         |
 
     When I run `wp <type> list --field=name`
     Then STDOUT should contain:
@@ -212,5 +208,5 @@ Feature: Manage WordPress themes and plugins
 
     Examples:
       | type   | type_name | item                    | item_title              | version | zip_file                                                               | file_to_check                                                     |
-      | theme  | Theme     | moina                      | Moina                      | 1.1.2   | https://wordpress.org/themes/download/moina.1.1.2.zip                     | {CONTENT_DIR}/moina/style.css                                        |
+      | theme  | Theme     | twentyten                      | Twenty Ten                      | 4.0   | https://wordpress.org/themes/download/twentyten.4.0.zip                     | {CONTENT_DIR}/twentyten/style.css                                        |
       | plugin | Plugin    | category-checklist-tree | Category Checklist Tree | 1.2     | https://downloads.wordpress.org/plugin/category-checklist-tree.1.2.zip | {CONTENT_DIR}/category-checklist-tree/category-checklist-tree.php |

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -271,6 +271,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'file'               => $file,
 				'auto_update'        => false,
 				'tested_up_to'       => '',
+				'requires'           => '',
+				'requires_php'       => '',
 				'wporg_status'       => $wporg_info['status'],
 				'wporg_last_updated' => $wporg_info['last_updated'],
 			);
@@ -293,6 +295,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'auto_update'        => false,
 				'author'             => $item_data['Author'],
 				'tested_up_to'       => '',
+				'requires'           => '',
+				'requires_php'       => '',
 				'wporg_status'       => '',
 				'wporg_last_updated' => '',
 			];
@@ -740,6 +744,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	}
 
 	protected function get_item_list() {
+		global $wp_version;
+
 		$items           = [];
 		$duplicate_names = [];
 
@@ -760,29 +766,62 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			$update_info     = ( isset( $all_update_info->response[ $file ] ) && null !== $all_update_info->response[ $file ] ) ? (array) $all_update_info->response[ $file ] : null;
 			$name            = Utils\get_plugin_name( $file );
 			$wporg_info      = $this->get_wporg_data( $name );
+			$plugin_data     = get_plugin_data( WP_PLUGIN_DIR . '/' . $file, false, false );
 
 			if ( ! isset( $duplicate_names[ $name ] ) ) {
 				$duplicate_names[ $name ] = array();
 			}
 
+			$php_version = PHP_VERSION;
+
+			$requires     = isset( $update_info ) && isset( $update_info['requires'] ) ? $update_info['requires'] : null;
+			$requires_php = isset( $update_info ) && isset( $update_info['requires_php'] ) ? $update_info['requires_php'] : null;
+
+			// If an update has requires_php set, check to see if the local version of PHP meets that requirement
+			// The plugins update API already filters out plugins that don't meet WordPress requirements, but does not
+			// filter out plugins based on PHP requirements -- so we must do that here
+			$compatible_php = empty( $requires_php ) || version_compare( PHP_VERSION, $requires_php, '>=' );
+
+			if ( ! $compatible_php ) {
+				$update                    = 'unavailable';
+				$update_unavailable_reason = "Requires a newer version of PHP [$requires_php] than available [$php_version]";
+			} else {
+				$update = $update_info ? 'available' : 'none';
+			}
+
+			// requires and requires_php are only provided by the plugins update API in the case of an update available.
+			// For display consistency, get these values from the current plugin file if they aren't in this response
+			if ( null === $requires ) {
+				$requires = ! empty( $plugin_data['RequiresWP'] ) ? $plugin_data['RequiresWP'] : '';
+			}
+
+			if ( null === $requires_php ) {
+					$requires_php = ! empty( $plugin_data['RequiresPHP'] ) ? $plugin_data['RequiresPHP'] : '';
+			}
+
 			$duplicate_names[ $name ][] = $file;
 			$items[ $file ]             = [
-				'name'               => $name,
-				'status'             => $this->get_status( $file ),
-				'update'             => (bool) $update_info,
-				'update_version'     => isset( $update_info ) && isset( $update_info['new_version'] ) ? $update_info['new_version'] : null,
-				'update_package'     => isset( $update_info ) && isset( $update_info['package'] ) ? $update_info['package'] : null,
-				'version'            => $details['Version'],
-				'update_id'          => $file,
-				'title'              => $details['Name'],
-				'description'        => wordwrap( $details['Description'] ),
-				'file'               => $file,
-				'auto_update'        => in_array( $file, $auto_updates, true ),
-				'author'             => $details['Author'],
-				'tested_up_to'       => '',
-				'wporg_status'       => $wporg_info['status'],
-				'wporg_last_updated' => $wporg_info['last_updated'],
-				'recently_active'    => in_array( $file, array_keys( $recently_active ), true ),
+				'name'                      => $name,
+				'status'                    => $this->get_status( $file ),
+				'update'                    => $update,
+				'update_version'            => isset( $update_info ) && isset( $update_info['new_version'] ) ? $update_info['new_version'] : null,
+				'update_package'            => isset( $update_info ) && isset( $update_info['package'] ) ? $update_info['package'] : null,
+				'version'                   => $details['Version'],
+				'update_id'                 => $file,
+				'title'                     => $details['Name'],
+				'description'               => wordwrap( $details['Description'] ),
+				'file'                      => $file,
+				'auto_update'               => in_array( $file, $auto_updates, true ),
+				'author'                    => $details['Author'],
+				'tested_up_to'              => '',
+				'requires'                  => $requires,
+				'requires_php'              => $requires_php,
+				'wporg_status'              => $wporg_info['status'],
+				'wporg_last_updated'        => $wporg_info['last_updated'],
+
+				'recently_active'           => in_array( $file, array_keys( $recently_active ), true ),
+
+				'update_unavailable_reason' => isset( $update_unavailable_reason ) ? $update_unavailable_reason : '',
 			];
 
 			if ( $this->check_headers['tested_up_to'] ) {
@@ -817,9 +856,25 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				// Get info for all plugins that don't have an update.
 				$plugin_update_info = isset( $all_update_info->no_update[ $file ] ) ? $all_update_info->no_update[ $file ] : null;
 
-				// Compare version and update information in plugin list.
+				// Check if local version is newer than what is listed upstream.
 				if ( null !== $plugin_update_info && version_compare( $details['Version'], $plugin_update_info->new_version, '>' ) ) {
-					$items[ $file ]['update'] = static::INVALID_VERSION_MESSAGE;
+					$items[ $file ]['update']       = static::INVALID_VERSION_MESSAGE;
+					$items[ $file ]['requires']     = isset( $plugin_update_info->requires ) ? $plugin_update_info->requires : null;
+					$items[ $file ]['requires_php'] = isset( $plugin_update_info->requires_php ) ? $plugin_update_info->requires_php : null;
+				}
+
+				// If there is a plugin in no_update with a newer version than the local copy, it is because the plugins update api
+				// has already filtered it because the local WordPress version is too low
+				if ( null !== $plugin_update_info && version_compare( $details['Version'], $plugin_update_info->new_version, '<' ) ) {
+					$items[ $file ]['update']         = 'unavailable';
+					$items[ $file ]['update_version'] = $plugin_update_info->new_version;
+					$items[ $file ]['requires']       = isset( $plugin_update_info->requires ) ? $plugin_update_info->requires : null;
+					$items[ $file ]['requires_php']   = isset( $plugin_update_info->requires_php ) ? $plugin_update_info->requires_php : null;
+
+					$reason = "Requires a newer version of WordPress [$plugin_update_info->requires] than installed [$wp_version]";
+
+					$items[ $file ]['update_unavailable_reason'] = $reason;
+
 				}
 			}
 		}
@@ -1397,6 +1452,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * * file
 	 * * author
 	 * * tested_up_to
+	 * * requires
+	 * * requires_php
 	 * * wporg_status
 	 * * wporg_last_updated
 	 *
@@ -1488,7 +1545,6 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		if ( is_plugin_active_for_network( $file ) ) {
 			return 'active-network';
 		}
-
 		if ( is_plugin_active( $file ) ) {
 			return 'active';
 		}

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -772,8 +772,6 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				$duplicate_names[ $name ] = array();
 			}
 
-			$php_version = PHP_VERSION;
-
 			$requires     = isset( $update_info ) && isset( $update_info['requires'] ) ? $update_info['requires'] : null;
 			$requires_php = isset( $update_info ) && isset( $update_info['requires_php'] ) ? $update_info['requires_php'] : null;
 
@@ -783,8 +781,13 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			$compatible_php = empty( $requires_php ) || version_compare( PHP_VERSION, $requires_php, '>=' );
 
 			if ( ! $compatible_php ) {
-				$update                    = 'unavailable';
-				$update_unavailable_reason = "Requires a newer version of PHP [$requires_php] than available [$php_version]";
+				$update = 'unavailable';
+
+				$update_unavailable_reason = sprintf(
+					'This update requires PHP version %s, but the version installed is %s.',
+					$requires_php,
+					PHP_VERSION
+				);
 			} else {
 				$update = $update_info ? 'available' : 'none';
 			}
@@ -818,9 +821,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				'requires_php'              => $requires_php,
 				'wporg_status'              => $wporg_info['status'],
 				'wporg_last_updated'        => $wporg_info['last_updated'],
-
 				'recently_active'           => in_array( $file, array_keys( $recently_active ), true ),
-
 				'update_unavailable_reason' => isset( $update_unavailable_reason ) ? $update_unavailable_reason : '',
 			];
 
@@ -871,7 +872,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 					$items[ $file ]['requires']       = isset( $plugin_update_info->requires ) ? $plugin_update_info->requires : null;
 					$items[ $file ]['requires_php']   = isset( $plugin_update_info->requires_php ) ? $plugin_update_info->requires_php : null;
 
-					$reason = "Requires a newer version of WordPress [$plugin_update_info->requires] than installed [$wp_version]";
+					$reason = "This update requires WordPress version $plugin_update_info->requires, but the version installed is $wp_version.";
 
 					$items[ $file ]['update_unavailable_reason'] = $reason;
 

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -103,7 +103,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		$padding = $this->get_padding( $items );
 
 		foreach ( $items as $file => $details ) {
-			if ( $details['update'] ) {
+			if ( 'available' === $details['update'] ) {
 				$line = ' %yU%n';
 			} else {
 				$line = '  ';
@@ -150,8 +150,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 				$this->map['long'][ $status ]
 			);
 		}
-
-		if ( in_array( true, wp_list_pluck( $items, 'update' ), true ) ) {
+		if ( in_array( 'available', wp_list_pluck( $items, 'update' ), true ) ) {
 			$legend_line[] = '%yU = Update Available%n';
 		}
 
@@ -375,7 +374,12 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			$errors = count( $args ) - count( $items );
 		}
 
-		$items_to_update = wp_list_filter( $items, [ 'update' => true ] );
+		$items_to_update = array_filter(
+			$items,
+			function ( $item ) {
+				return isset( $item['update'] ) && $item['update'] !== 'none';
+			}
+		);
 
 		$minor = (bool) Utils\get_flag_value( $assoc_args, 'minor', false );
 		$patch = (bool) Utils\get_flag_value( $assoc_args, 'patch', false );
@@ -414,6 +418,11 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		foreach ( $items_to_update as $item_key => $item_info ) {
 			if ( static::INVALID_VERSION_MESSAGE === $item_info['update'] ) {
 				WP_CLI::warning( "{$item_info['name']}: " . static::INVALID_VERSION_MESSAGE . '.' );
+				++$skipped;
+				unset( $items_to_update[ $item_key ] );
+			}
+			if ( 'unavailable' === $item_info['update'] ) {
+				WP_CLI::warning( "{$item_info['name']}: {$item_info['update_unavailable_reason']}" );
 				++$skipped;
 				unset( $items_to_update[ $item_key ] );
 			}
@@ -564,10 +573,14 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 			foreach ( $item as $field => &$value ) {
 				if ( 'update' === $field ) {
-					if ( true === $value ) {
-						$value = 'available';
-					} elseif ( false === $value ) {
-						$value = 'none';
+					// If an update is unavailable, make sure to also show these fields which will explain why
+					if ( 'unavailable' === $value ) {
+						if ( ! in_array( 'requires', $this->obj_fields, true ) ) {
+							array_push( $this->obj_fields, 'requires' );
+						}
+						if ( ! in_array( 'requires_php', $this->obj_fields, true ) ) {
+							array_push( $this->obj_fields, 'requires_php' );
+						}
 					}
 				} elseif ( 'auto_update' === $field ) {
 					if ( true === $value ) {

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -377,7 +377,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		$items_to_update = array_filter(
 			$items,
 			function ( $item ) {
-				return isset( $item['update'] ) && $item['update'] !== 'none';
+				return isset( $item['update'] ) && 'none' !== $item['update'];
 			}
 		);
 

--- a/src/WP_CLI/ParseThemeNameInput.php
+++ b/src/WP_CLI/ParseThemeNameInput.php
@@ -94,9 +94,10 @@ trait ParseThemeNameInput {
 			$compatible_wp  = empty( $requires ) || version_compare( $wp_version, $requires, '>=' );
 
 			if ( ! $compatible_php ) {
-				$update                    = 'unavailable';
+				$update = 'unavailable';
+
 				$update_unavailable_reason = sprintf(
-					'Requires a newer version of PHP [%s] than installed [%s]',
+					'This update requires PHP version %s, but the version installed is %s.',
 					$requires_php,
 					PHP_VERSION
 				);
@@ -105,8 +106,9 @@ trait ParseThemeNameInput {
 			}
 
 			if ( ! $compatible_wp ) {
-				$update                    = 'unavailable';
-				$update_unavailable_reason = "Requires a newer version of WordPress [$requires] than installed [$wp_version]";
+				$update = 'unavailable';
+
+				$update_unavailable_reason = "This update requires WordPress version $requires, but the version installed is $wp_version.";
 			} else {
 				$update = $update_info ? 'available' : 'none';
 			}

--- a/src/WP_CLI/ParseThemeNameInput.php
+++ b/src/WP_CLI/ParseThemeNameInput.php
@@ -101,14 +101,14 @@ trait ParseThemeNameInput {
 					$requires_php,
 					PHP_VERSION
 				);
-			} else {
-				$update = $update_info ? 'available' : 'none';
-			}
-
-			if ( ! $compatible_wp ) {
+			} elseif ( ! $compatible_wp ) {
 				$update = 'unavailable';
 
-				$update_unavailable_reason = "This update requires WordPress version $requires, but the version installed is $wp_version.";
+				$update_unavailable_reason = sprintf(
+					'This update requires WordPress version %s, but the version installed is %s.',
+					$requires,
+					$wp_version
+				);
 			} else {
 				$update = $update_info ? 'available' : 'none';
 			}

--- a/src/WP_CLI/ParseThemeNameInput.php
+++ b/src/WP_CLI/ParseThemeNameInput.php
@@ -45,6 +45,11 @@ trait ParseThemeNameInput {
 	 * @return array
 	 */
 	private function get_all_themes() {
+		global $wp_version;
+		// Extract the major WordPress version (e.g., "6.3") from the full version string
+		list($wp_core_version) = explode( '-', $wp_version );
+		$wp_core_version       = implode( '.', array_slice( explode( '.', $wp_core_version ), 0, 2 ) );
+
 		$items              = array();
 		$theme_version_info = array();
 
@@ -76,22 +81,60 @@ trait ParseThemeNameInput {
 		}
 
 		foreach ( wp_get_themes() as $key => $theme ) {
-			$stylesheet = $theme->get_stylesheet();
-
+			$stylesheet  = $theme->get_stylesheet();
 			$update_info = ( isset( $all_update_info->response[ $stylesheet ] ) && null !== $all_update_info->response[ $theme->get_stylesheet() ] ) ? (array) $all_update_info->response[ $theme->get_stylesheet() ] : null;
 
+			// Unlike plugin update responses, the wordpress.org API does not seem to check and filter themes that don't meet
+			// WordPress version requirements into a separate no_updates array
+			// Also unlike plugin update responses, the wordpress.org API seems to always include requires AND requires_php
+			$requires     = isset( $update_info ) && isset( $update_info['requires'] ) ? $update_info['requires'] : null;
+			$requires_php = isset( $update_info ) && isset( $update_info['requires_php'] ) ? $update_info['requires_php'] : null;
+
+			$compatible_php = empty( $requires_php ) || version_compare( PHP_VERSION, $requires_php, '>=' );
+			$compatible_wp  = empty( $requires ) || version_compare( $wp_version, $requires, '>=' );
+
+			if ( ! $compatible_php ) {
+				$update                    = 'unavailable';
+				$update_unavailable_reason = sprintf(
+					'Requires a newer version of PHP [%s] than installed [%s]',
+					$requires_php,
+					PHP_VERSION
+				);
+			} else {
+				$update = $update_info ? 'available' : 'none';
+			}
+
+			if ( ! $compatible_wp ) {
+				$update                    = 'unavailable';
+				$update_unavailable_reason = "Requires a newer version of WordPress [$requires] than installed [$wp_version]";
+			} else {
+				$update = $update_info ? 'available' : 'none';
+			}
+
+			// For display consistency, get these values from the current plugin file if they aren't in this response
+			if ( null === $requires ) {
+				$requires = ! empty( $theme->get( 'RequiresWP' ) ) ? $theme->get( 'RequiresWP' ) : '';
+			}
+
+			if ( null === $requires_php ) {
+				$requires_php = ! empty( $theme->get( 'RequiresPHP' ) ) ? $theme->get( 'RequiresPHP' ) : '';
+			}
+
 			$items[ $stylesheet ] = [
-				'name'           => $key,
-				'status'         => $this->get_status( $theme ),
-				'update'         => (bool) $update_info,
-				'update_version' => isset( $update_info['new_version'] ) ? $update_info['new_version'] : null,
-				'update_package' => isset( $update_info['package'] ) ? $update_info['package'] : null,
-				'version'        => $theme->get( 'Version' ),
-				'update_id'      => $stylesheet,
-				'title'          => $theme->get( 'Name' ),
-				'description'    => wordwrap( $theme->get( 'Description' ) ),
-				'author'         => $theme->get( 'Author' ),
-				'auto_update'    => in_array( $stylesheet, $auto_updates, true ),
+				'name'                      => $key,
+				'status'                    => $this->get_status( $theme ),
+				'update'                    => $update,
+				'update_version'            => isset( $update_info['new_version'] ) ? $update_info['new_version'] : null,
+				'update_package'            => isset( $update_info['package'] ) ? $update_info['package'] : null,
+				'version'                   => $theme->get( 'Version' ),
+				'update_id'                 => $stylesheet,
+				'title'                     => $theme->get( 'Name' ),
+				'description'               => wordwrap( $theme->get( 'Description' ) ),
+				'author'                    => $theme->get( 'Author' ),
+				'auto_update'               => in_array( $stylesheet, $auto_updates, true ),
+				'requires'                  => $requires,
+				'requires_php'              => $requires_php,
+				'update_unavailable_reason' => isset( $update_unavailable_reason ) ? $update_unavailable_reason : '',
 			];
 
 			// Compare version and update information in theme list.


### PR DESCRIPTION
This introduces a new update sate of 'unavailable' which is when there is a new version of a theme/plugin upstream but the local WordPress / PHP requirements do not meet the requirements set by the authors.

What this changes:

Changes the `update` field of an item from a bool which laters gets turned into 'available' or 'none' to a string which will be either `'available'`, `'none'`, or `'unavailable'`. New `unavailable` is based off a check against WordPress and PHP requirements via the `requires` and `requires_php` fields.


```
$ wp plugin list
+----------------+----------+-------------+---------+----------------+-------------+----------+--------------+
| name           | status   | update      | version | update_version | auto_update | requires | requires_php |
+----------------+----------+-------------+---------+----------------+-------------+----------+--------------+
| akismet        | inactive | available   | 5.1     | 5.3.5          | off         | 5.8      | 5.6.20       |
| edit-flow      | inactive | none        | 0.9.9   |                | off         | 6.0      | 8.0          |
| wp-super-cache | inactive | unavailable | 1.9.4   | 1.12.4         | off         | 6.5      | 7.0          |
+----------------+----------+-------------+---------+----------------+-------------+----------+--------------+
```

```
$ wp plugin update wp-super-cache
Warning: wp-super-cache: This update requires WordPress version 6.5, but the version installed is 6.2.
Error: No plugins updated.
```

This works similarly for PHP versions too:
```
$ php -v
PHP 7.4.33 (cli) (built: Dec 16 2024 20:48:31) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.33, Copyright (c), by Zend Technologies
$ wp plugin list
+----------------+----------+-------------+---------+----------------+-------------+----------+--------------+
| name           | status   | update      | version | update_version | auto_update | requires | requires_php |
+----------------+----------+-------------+---------+----------------+-------------+----------+--------------+
| akismet        | inactive | available   | 5.1     | 5.3.5          | off         | 5.8      | 5.6.20       |
| edit-flow      | inactive | unavailable | 0.9.8   | 0.9.9          | off         | 6.0      | 8.0          |
| wp-super-cache | inactive | unavailable | 1.9.4   | 1.12.4         | off         | 6.5      | 7.0          |
+----------------+----------+-------------+---------+----------------+-------------+----------+--------------+
$ wp plugin update edit-flow
Warning: edit-flow: This update requires PHP version 8.0, but the version installed is 7.4.
Error: No plugins updated.
```

This also fixes issues like #428 by removing incompatible updates from a command like:
```
$ wp plugin list --update=available
+---------+----------+-----------+---------+----------------+-------------+----------+--------------+
| name    | status   | update    | version | update_version | auto_update | requires | requires_php |
+---------+----------+-----------+---------+----------------+-------------+----------+--------------+
| akismet | inactive | available | 5.1     | 5.3.5          | off         | 5.8      | 5.6.20       |
+---------+----------+-----------+---------+----------------+-------------+----------+--------------+
```

This also adds the fields `requires` and `requires_php`. While these aren't default fields,  I did change it so that it will include them by default if one of the plugins has an update sate of unavailable (so it is immediately clear why the update is unavailable). 

I've also written it so that `requires` and `requires_php` fields will use either what is provided for the latest version in the case of an update (unavailable or not) or whatever is listed in the current plugin file.

This means that in the case of 'none' it i showing the requirements for the current version, while in the case of 'available' or 'unavailable' it is showing the requirements for the `update_version`. This could be a bit confusing, but it made even less sense the other way to have it list an update as 'unavailable' while showing the older and already met requirements from the currently installed version. Those were just my initial idea, so any feedback welcome there. Similar to the field names, etc...

Finally, I couldn't find much documentation about the wordpress.org update API, but what I saw in testing is:

For plugins, the wordpress.org api will check the version of WordPress sent in the header of the request from wp core and if the latest upstream version requires a newer version of WordPress, it moves that plugin into the `no_update` section of the response, along with any other plugins that just don't have an update available. It doesn't know the current version of PHP, so it can't check that. The current situation is that if an upstream update requires a newer version of WordPress then WP CLI doesn't see it at all, because it doesn't look for it in the `no_updates` section of the response. If it requires a newer version of PHP, WP CLI will show it as an available update because it doesn't know about the PHP incompatibility.

For themes, it doesn't seem to do that same filtering.

This PR fixes both those cases by correctly showing the updates as `unavailable` rather than not existing or ready to install. My main use case is that I want to be able to run `wp plugin list` and see if a site is running the latest version of any installed plugin or theme. If not, I want to know if it is because the updates haven't been applied or if they are held back because of requirement changes in newer versions.