### PR TITLE
Fix failing tests

### DIFF
--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -95,7 +95,8 @@ Feature: Update WordPress plugins
       0.5.2
       """
 
-  @require-wp-4.0
+  # Akismet currently requires WordPress 5.8
+  @require-wp-5.8
   Scenario: Update a plugin to its latest minor release
     Given a WP install
     And I run `wp plugin install --force akismet --version=2.5.4`
@@ -196,7 +197,8 @@ Feature: Update WordPress plugins
       Error: Can't find the requested plugin's version 2.5.4 in the WordPress.org plugin repository (HTTP code 404).
       """
 
-  @require-wp-4.7
+  # Akismet currently requires WordPress 5.8
+  @require-wp-5.8
   Scenario: Plugin updates that error should not report a success
     Given a WP install
     And I run `wp plugin install --force akismet --version=4.0`
@@ -223,6 +225,8 @@ Feature: Update WordPress plugins
       Success:
       """
 
+  # Akismet currently requires WordPress 5.8, so there's a warning because of it.
+  @require-wp-5.8
   Scenario: Excluding a missing plugin should not throw an error
     Given a WP install
     And I run `wp plugin update --all --exclude=missing-plugin`

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -107,7 +107,8 @@ Feature: Manage WordPress plugins
     And STDOUT should be empty
     And the return code should be 1
 
-  @require-wp-4.0
+  # WordPress Importer currently requires at least WP 5.2.
+  @require-wp-5.2
   Scenario: Install a plugin, activate, then force install an older version of the plugin
     Given a WP install
 

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -579,7 +579,8 @@ Feature: Manage WordPress plugins
       """
     And the return code should be 0
 
-  @require-wp-4.7
+  # Akismet currently requires WordPress 5.8, so there's a warning because of it.
+  @require-wp-5.8
   Scenario: Plugin hidden by "all_plugins" filter
     Given a WP install
     And these installed and active plugins:

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -61,7 +61,7 @@ Feature: Manage WordPress plugins
     When I run `wp plugin status`
     Then STDOUT should not be empty
 
-    When I run `wp plugin list`
+    When I run `wp plugin list --fields=name,status,update,version,update_version,auto_update`
     Then STDOUT should be a table containing rows:
       | name       | status | update | version | update_version | auto_update |
       | Zombieland | active | none   | 0.1.0   |                | off         |
@@ -586,7 +586,7 @@ Feature: Manage WordPress plugins
     Given a WP install
     And these installed and active plugins:
       """
-      akismet
+      hello-dolly
       site-secrets
       """
     And a wp-content/mu-plugins/hide-us-plugin.php file:
@@ -755,7 +755,7 @@ Feature: Manage WordPress plugins
       """
     And I run `wp plugin activate foo`
 
-    When I run `wp plugin list`
+    When I run `wp plugin list --fields=name,status,update,version,update_version,auto_update`
     Then STDOUT should be a table containing rows:
       | name       | status   | update  | version  | update_version | auto_update |
       | foo        | active   | none    |          |                | off         |
@@ -797,7 +797,7 @@ Feature: Manage WordPress plugins
       """
     And I run `wp plugin activate foo`
 
-    When I run `wp plugin list`
+    When I run `wp plugin list --fields=name,status,update,version,update_version,auto_update`
     Then STDOUT should be a table containing rows:
       | name       | status   | update  | version  | update_version | auto_update |
       | foo        | active   | none    |          |                | off         |

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -6,6 +6,8 @@ Feature: Manage WordPress themes and plugins
   @require-wp-4.5
   Scenario Outline: Installing, upgrading and deleting a theme or plugin
     Given a WP install
+    # Akismet ships with WordPress but does not work with older versions we test
+    And I run `wp plugin delete akismet`
     And I run `wp <type> path`
     And save STDOUT as {CONTENT_DIR}
 

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -209,5 +209,5 @@ Feature: Manage WordPress themes and plugins
 
     Examples:
       | type   | type_name | item                    | item_title              | version | zip_file                                                               | file_to_check                                                     |
-      | theme  | Theme     | moina                      | Moina                      | 1.1.2   | https://wordpress.org/themes/download/moina.1.1.2.zip                     | {CONTENT_DIR}/moina/style.css                                        |
+      | theme  | Theme     | moina                   | Moina                   | 1.1.2   | https://wordpress.org/themes/download/moina.1.1.2.zip                  | {CONTENT_DIR}/moina/style.css                                     |
       | plugin | Plugin    | category-checklist-tree | Category Checklist Tree | 1.2     | https://downloads.wordpress.org/plugin/category-checklist-tree.1.2.zip | {CONTENT_DIR}/category-checklist-tree/category-checklist-tree.php |

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1255,6 +1255,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 			foreach ( $deleted as $plugin_file ) {
 				unset( $current->response[ $plugin_file ] );
+				unset( $current->checked[ $plugin_file ] );
 			}
 
 			set_site_transient( $this->upgrade_transient, $current );


### PR DESCRIPTION
Fixes some tests on WordPress 4.9.

There's also one failing test against WordPress trunk, but not sure why.

Started on the 5th but was fine on the 4th. See https://github.com/wp-cli/extension-command/actions/runs/13644528411
and https://github.com/wp-cli/extension-command/actions/runs/13666785798.

Thought maybe https://core.trac.wordpress.org/changeset/59926 is related. Otherwise couldn't find a suspicious commit.

https://github.com/wp-cli/extension-command/actions/runs/13755011683/job/38461015602#step:11:127