### PR TITLE
Fix fatal error issue in in_array function

### DIFF
--- a/features/plugin-auto-updates-status.feature
+++ b/features/plugin-auto-updates-status.feature
@@ -114,3 +114,10 @@ Feature: Show the status of auto-updates for WordPress plugins
       hello,disabled
       duplicate-post,disabled
       """
+
+  @require-wp-5.5
+  Scenario: Handle malformed option value
+    When I run `wp option update auto_update_plugins ""`
+    When I try `wp plugin auto-updates status hello`
+    Then the return code should be 0
+    And STDERR should be empty

--- a/features/plugin-auto-updates-status.feature
+++ b/features/plugin-auto-updates-status.feature
@@ -118,6 +118,6 @@ Feature: Show the status of auto-updates for WordPress plugins
   @require-wp-5.5
   Scenario: Handle malformed option value
     When I run `wp option update auto_update_plugins ""`
-    When I try `wp plugin auto-updates status hello`
+    And I try `wp plugin auto-updates status hello`
     Then the return code should be 0
     And STDERR should be empty

--- a/src/Plugin_AutoUpdates_Command.php
+++ b/src/Plugin_AutoUpdates_Command.php
@@ -85,7 +85,7 @@ class Plugin_AutoUpdates_Command {
 		$plugins      = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
 
-		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
+		if ( ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 
@@ -162,7 +162,7 @@ class Plugin_AutoUpdates_Command {
 		$plugins      = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
 
-		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
+		if ( ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 
@@ -278,7 +278,7 @@ class Plugin_AutoUpdates_Command {
 		$plugins      = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
 
-		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
+		if ( ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 

--- a/src/Plugin_AutoUpdates_Command.php
+++ b/src/Plugin_AutoUpdates_Command.php
@@ -85,7 +85,7 @@ class Plugin_AutoUpdates_Command {
 		$plugins      = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
 
-		if ( false === $auto_updates ) {
+		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 
@@ -162,7 +162,7 @@ class Plugin_AutoUpdates_Command {
 		$plugins      = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
 
-		if ( false === $auto_updates ) {
+		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 
@@ -278,7 +278,7 @@ class Plugin_AutoUpdates_Command {
 		$plugins      = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
 
-		if ( false === $auto_updates ) {
+		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -751,7 +751,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 		$auto_updates = get_site_option( Plugin_AutoUpdates_Command::SITE_OPTION );
 
-		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
+		if ( ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -751,7 +751,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 		$auto_updates = get_site_option( Plugin_AutoUpdates_Command::SITE_OPTION );
 
-		if ( false === $auto_updates ) {
+		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 

--- a/src/Theme_AutoUpdates_Command.php
+++ b/src/Theme_AutoUpdates_Command.php
@@ -85,7 +85,7 @@ class Theme_AutoUpdates_Command {
 		$themes       = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
 
-		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
+		if ( ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 
@@ -162,7 +162,7 @@ class Theme_AutoUpdates_Command {
 		$themes       = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
 
-		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
+		if ( ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 
@@ -278,7 +278,7 @@ class Theme_AutoUpdates_Command {
 		$themes       = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
 
-		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
+		if ( ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 

--- a/src/Theme_AutoUpdates_Command.php
+++ b/src/Theme_AutoUpdates_Command.php
@@ -85,7 +85,7 @@ class Theme_AutoUpdates_Command {
 		$themes       = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
 
-		if ( false === $auto_updates ) {
+		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 
@@ -162,7 +162,7 @@ class Theme_AutoUpdates_Command {
 		$themes       = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
 
-		if ( false === $auto_updates ) {
+		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 
@@ -278,7 +278,7 @@ class Theme_AutoUpdates_Command {
 		$themes       = $this->fetcher->get_many( $args );
 		$auto_updates = get_site_option( static::SITE_OPTION );
 
-		if ( false === $auto_updates ) {
+		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 

--- a/src/WP_CLI/ParseThemeNameInput.php
+++ b/src/WP_CLI/ParseThemeNameInput.php
@@ -76,7 +76,7 @@ trait ParseThemeNameInput {
 
 		$auto_updates = get_site_option( Theme_AutoUpdates_Command::SITE_OPTION );
 
-		if ( false === $auto_updates ) {
+		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 

--- a/src/WP_CLI/ParseThemeNameInput.php
+++ b/src/WP_CLI/ParseThemeNameInput.php
@@ -76,7 +76,7 @@ trait ParseThemeNameInput {
 
 		$auto_updates = get_site_option( Theme_AutoUpdates_Command::SITE_OPTION );
 
-		if ( false === $auto_updates || ! is_array( $auto_updates ) ) {
+		if ( ! is_array( $auto_updates ) ) {
 			$auto_updates = [];
 		}
 


### PR DESCRIPTION
Fix: https://github.com/wp-cli/extension-command/issues/429

A fatal error occurred in the in_array function when the site options auto_update_plugins and auto_update_themes were set to string values. I fixed this by adding a condition to check if they are not arrays.