### PR TITLE
Don't use transient values when doing wp plugin|theme list

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -318,6 +318,27 @@ Feature: Manage WordPress plugins
       Automattic
       """
 
+    When I run `wp eval 'echo get_site_transient("update_plugins")->last_checked;'`
+    And save STDOUT as {LAST_UPDATED}
+
+    When I run `wp plugin list --skip-update-check`
+    Then STDOUT should not be empty
+
+    When I run `wp eval 'echo get_site_transient("update_plugins")->last_checked;'`
+    Then STDOUT should be:
+      """
+      {LAST_UPDATED}
+      """
+
+    When I run `wp plugin list`
+    Then STDOUT should not be empty
+
+    When I run `wp eval 'echo get_site_transient("update_plugins")->last_checked;'`
+    Then STDOUT should not contain:
+      """
+      {LAST_UPDATED}
+      """
+
   Scenario: List plugin by multiple statuses
     Given a WP multisite install
     And a wp-content/plugins/network-only.php file:

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -233,6 +233,34 @@ Feature: Manage WordPress themes
       | name      | status   | update |
       | astra     | inactive | none   |
 
+
+  Scenario: Doing wp theme list does a force check by default, deleting any existing transient values
+    Given a WP install
+
+    When I run `wp theme list`
+    Then STDOUT should not be empty
+
+    When I run `wp eval 'echo get_site_transient("update_themes")->last_checked;'`
+    And save STDOUT as {LAST_UPDATED}
+
+    When I run `wp theme list --skip-update-check`
+    Then STDOUT should not be empty
+
+    When I run `wp eval 'echo get_site_transient("update_themes")->last_checked;'`
+    Then STDOUT should be:
+      """
+      {LAST_UPDATED}
+      """
+
+    When I run `wp theme list`
+    Then STDOUT should not be empty
+
+    When I run `wp eval 'echo get_site_transient("update_themes")->last_checked;'`
+    Then STDOUT should not contain:
+      """
+      {LAST_UPDATED}
+      """
+
   Scenario: Install a theme when the theme directory doesn't yet exist
     Given a WP install
     And I run `wp theme delete --all --force`

--- a/src/WP_CLI/CommandWithUpgrade.php
+++ b/src/WP_CLI/CommandWithUpgrade.php
@@ -543,6 +543,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		// Force WordPress to check for updates if `--skip-update-check` is not passed.
 		if ( false === (bool) Utils\get_flag_value( $assoc_args, 'skip-update-check', false ) ) {
+			delete_site_transient( $this->upgrade_transient );
 			call_user_func( $this->upgrade_refresh );
 		}
 


### PR DESCRIPTION
This changes the default behavior to always check wordpress.org for the latest information when doing wp plugin|theme list unless the existing `--skip-update-check` flag is passed.

This came out of the discussion in #426 and replaces that PR. The main idea is that it doesn't make any sense to have both `--force-check` and `--skip-update-check` flags while also having the default behavior be unpredictable depending on the state of the transient.

I created a new PR since pretty much all of the code is test code and that is different now that we are changing the default behavior instead of adding a flag.