### PR TITLE
Add missing space in plugin install doc

### DIFF
--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -979,7 +979,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * for confirmation.
 	 *
 	 * [--ignore-requirements]
-	 * :If set, the command will install the plugin while ignoring any WordPress or PHP version requirements
+	 * : If set, the command will install the plugin while ignoring any WordPress or PHP version requirements
 	 * specified by the plugin authors.
 	 *
 	 * [--activate]


### PR DESCRIPTION
Fixes formatting issue in handbook. https://developer.wordpress.org/cli/commands/plugin/install/

<img width="570" height="273" alt="Screenshot 2025-07-13 at 9 19 15 PM" src="https://github.com/user-attachments/assets/a041c898-d11a-4195-be75-74fc01f6b194" />

