### PR TITLE
Fix tests for Hello Dolly

### DIFF
--- a/features/plugin-activate.feature
+++ b/features/plugin-activate.feature
@@ -21,21 +21,20 @@ Feature: Activate WordPress plugins
       """
     And the return code should be 1
 
-    When I try `wp plugin activate akismet hello debug-bar`
+    When I try `wp plugin activate akismet debug-bar`
     Then STDERR should be:
       """
       Warning: The 'debug-bar' plugin could not be found.
-      Error: Only activated 2 of 3 plugins.
+      Error: Only activated 1 of 2 plugins.
       """
     And STDOUT should be:
       """
       Plugin 'akismet' activated.
-      Plugin 'hello' activated.
       """
     And the return code should be 1
 
   Scenario: Activate all when one plugin is hidden by "all_plugins" filter
-    Given I run `wp plugin install site-secrets`
+    Given I run `wp plugin install site-secrets https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip`
     And a wp-content/mu-plugins/hide-us-plugin.php file:
       """
       <?php
@@ -55,7 +54,7 @@ Feature: Activate WordPress plugins
     Then STDOUT should contain:
       """
       Plugin 'akismet' activated.
-      Plugin 'hello' activated.
+      Plugin 'sample-plugin' activated.
       """
     And STDOUT should not contain:
       """
@@ -135,7 +134,7 @@ Feature: Activate WordPress plugins
       """
 
   Scenario: Adding --exclude with plugin activate --all should exclude the plugins specified via --exclude
-    When I try `wp plugin activate --all --exclude=hello`
+    When I try `wp plugin activate --all --exclude=hello,hello-dolly`
     Then STDOUT should be:
       """
       Plugin 'akismet' activated.

--- a/features/plugin-auto-updates-disable.feature
+++ b/features/plugin-auto-updates-disable.feature
@@ -2,7 +2,7 @@ Feature: Disable auto-updates for WordPress plugins
 
   Background:
     Given a WP install
-    And I run `wp plugin install duplicate-post --ignore-requirements`
+    And I run `wp plugin install duplicate-post https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip --ignore-requirements`
     And I run `wp plugin auto-updates enable --all`
 
   @require-wp-5.5
@@ -16,7 +16,7 @@ Feature: Disable auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Disable auto-updates for a single plugin
-    When I run `wp plugin auto-updates disable hello`
+    When I run `wp plugin auto-updates disable sample-plugin`
     Then STDOUT should be:
       """
       Success: Disabled 1 of 1 plugin auto-updates.
@@ -25,7 +25,7 @@ Feature: Disable auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Disable auto-updates for multiple plugins
-    When I run `wp plugin auto-updates disable hello duplicate-post`
+    When I run `wp plugin auto-updates disable sample-plugin duplicate-post`
     Then STDOUT should be:
       """
       Success: Disabled 2 of 2 plugin auto-updates.
@@ -46,11 +46,11 @@ Feature: Disable auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Disable auto-updates for already disabled plugins
-    When I run `wp plugin auto-updates disable hello`
+    When I run `wp plugin auto-updates disable sample-plugin`
     And I try `wp plugin auto-updates disable --all`
     Then STDERR should contain:
       """
-      Warning: Auto-updates already disabled for plugin hello.
+      Warning: Auto-updates already disabled for plugin sample-plugin.
       """
     And STDERR should contain:
       """
@@ -59,7 +59,7 @@ Feature: Disable auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Filter when disabling auto-updates for already enabled plugins
-    When I run `wp plugin auto-updates disable hello`
+    When I run `wp plugin auto-updates disable sample-plugin`
     And I run `wp plugin list --auto_update=on --format=count`
     Then save STDOUT as {PLUGIN_COUNT}
 
@@ -72,8 +72,8 @@ Feature: Disable auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Filter when disabling auto-updates for already disabled selection of plugins
-    When I run `wp plugin auto-updates disable hello`
-    And I run `wp plugin auto-updates disable hello duplicate-post --enabled-only`
+    When I run `wp plugin auto-updates disable sample-plugin`
+    And I run `wp plugin auto-updates disable sample-plugin duplicate-post --enabled-only`
     Then STDOUT should be:
       """
       Success: Disabled 1 of 1 plugin auto-updates.
@@ -82,8 +82,8 @@ Feature: Disable auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Filtering everything away produces an error
-    When I run `wp plugin auto-updates disable hello`
-    And I try `wp plugin auto-updates disable hello --enabled-only`
+    When I run `wp plugin auto-updates disable sample-plugin`
+    And I try `wp plugin auto-updates disable sample-plugin --enabled-only`
     Then STDERR should be:
       """
       Error: No plugins provided to disable auto-updates for.

--- a/features/plugin-auto-updates-enable.feature
+++ b/features/plugin-auto-updates-enable.feature
@@ -2,7 +2,7 @@ Feature: Enable auto-updates for WordPress plugins
 
   Background:
     Given a WP install
-    And I run `wp plugin install duplicate-post --ignore-requirements`
+    And I run `wp plugin install duplicate-post https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip --ignore-requirements`
 
   @require-wp-5.5
   Scenario: Show an error if required params are missing
@@ -15,7 +15,7 @@ Feature: Enable auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Enable auto-updates for a single plugin
-    When I run `wp plugin auto-updates enable hello`
+    When I run `wp plugin auto-updates enable sample-plugin`
     Then STDOUT should be:
       """
       Success: Enabled 1 of 1 plugin auto-updates.
@@ -24,7 +24,7 @@ Feature: Enable auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Enable auto-updates for multiple plugins
-    When I run `wp plugin auto-updates enable hello duplicate-post`
+    When I run `wp plugin auto-updates enable sample-plugin duplicate-post`
     Then STDOUT should be:
       """
       Success: Enabled 2 of 2 plugin auto-updates.
@@ -45,11 +45,11 @@ Feature: Enable auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Enable auto-updates for already enabled plugins
-    When I run `wp plugin auto-updates enable hello`
+    When I run `wp plugin auto-updates enable sample-plugin`
     And I try `wp plugin auto-updates enable --all`
     Then STDERR should contain:
       """
-      Warning: Auto-updates already enabled for plugin hello.
+      Warning: Auto-updates already enabled for plugin sample-plugin.
       """
     And STDERR should contain:
       """
@@ -58,7 +58,7 @@ Feature: Enable auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Filter when enabling auto-updates for already enabled plugins
-    When I run `wp plugin auto-updates enable hello`
+    When I run `wp plugin auto-updates enable sample-plugin`
     And I run `wp plugin list --status=inactive --auto_update=off --format=count`
     Then save STDOUT as {PLUGIN_COUNT}
 
@@ -71,8 +71,8 @@ Feature: Enable auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Filter when enabling auto-updates for already enabled selection of plugins
-    When I run `wp plugin auto-updates enable hello`
-    And I run `wp plugin auto-updates enable hello duplicate-post --disabled-only`
+    When I run `wp plugin auto-updates enable sample-plugin`
+    And I run `wp plugin auto-updates enable sample-plugin duplicate-post --disabled-only`
     Then STDOUT should be:
       """
       Success: Enabled 1 of 1 plugin auto-updates.
@@ -81,8 +81,8 @@ Feature: Enable auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Filtering everything away produces an error
-    When I run `wp plugin auto-updates enable hello`
-    And I try `wp plugin auto-updates enable hello --disabled-only`
+    When I run `wp plugin auto-updates enable sample-plugin`
+    And I try `wp plugin auto-updates enable sample-plugin --disabled-only`
     Then STDERR should be:
       """
       Error: No plugins provided to enable auto-updates for.

--- a/features/plugin-auto-updates-status.feature
+++ b/features/plugin-auto-updates-status.feature
@@ -2,7 +2,7 @@ Feature: Show the status of auto-updates for WordPress plugins
 
   Background:
     Given a WP install
-    And I run `wp plugin install duplicate-post --ignore-requirements`
+    And I run `wp plugin install duplicate-post https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip --ignore-requirements`
 
   @require-wp-5.5
   Scenario: Show an error if required params are missing
@@ -15,19 +15,19 @@ Feature: Show the status of auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: Show the status of auto-updates of a single plugin
-    When I run `wp plugin auto-updates status hello`
+    When I run `wp plugin auto-updates status sample-plugin`
     Then STDOUT should be a table containing rows:
       | name           | status   |
-      | hello          | disabled |
+      | sample-plugin          | disabled |
     And the return code should be 0
 
   @require-wp-5.5
   Scenario: Show the status of auto-updates multiple plugins
-    When I run `wp plugin auto-updates status duplicate-post hello`
+    When I run `wp plugin auto-updates status duplicate-post sample-plugin`
     Then STDOUT should be a table containing rows:
       | name           | status   |
       | duplicate-post | disabled |
-      | hello          | disabled |
+      | sample-plugin          | disabled |
     And the return code should be 0
 
   @require-wp-5.5
@@ -37,7 +37,7 @@ Feature: Show the status of auto-updates for WordPress plugins
       | name           | status   |
       | akismet        | disabled |
       | duplicate-post | disabled |
-      | hello          | disabled |
+      | sample-plugin          | disabled |
     And the return code should be 0
 
     When I run `wp plugin auto-updates enable --all`
@@ -46,25 +46,25 @@ Feature: Show the status of auto-updates for WordPress plugins
       | name           | status   |
       | akismet        | enabled  |
       | duplicate-post | enabled  |
-      | hello          | enabled  |
+      | sample-plugin          | enabled  |
     And the return code should be 0
 
   @require-wp-5.5
   Scenario: The status can be filtered to only show enabled or disabled plugins
-    Given I run `wp plugin auto-updates enable hello`
+    Given I run `wp plugin auto-updates enable sample-plugin`
 
     When I run `wp plugin auto-updates status --all`
     Then STDOUT should be a table containing rows:
       | name           | status   |
       | akismet        | disabled |
       | duplicate-post | disabled |
-      | hello          | enabled  |
+      | sample-plugin          | enabled  |
     And the return code should be 0
 
     When I run `wp plugin auto-updates status --all --enabled-only`
     Then STDOUT should be a table containing rows:
       | name           | status   |
-      | hello          | enabled  |
+      | sample-plugin          | enabled  |
     And the return code should be 0
 
     When I run `wp plugin auto-updates status --all --disabled-only`
@@ -83,7 +83,7 @@ Feature: Show the status of auto-updates for WordPress plugins
 
   @require-wp-5.5
   Scenario: The fields can be shown individually
-    Given I run `wp plugin auto-updates enable hello`
+    Given I run `wp plugin auto-updates enable sample-plugin`
 
     When I run `wp plugin auto-updates status --all --disabled-only --field=name`
     Then STDOUT should be:
@@ -92,7 +92,7 @@ Feature: Show the status of auto-updates for WordPress plugins
       duplicate-post
       """
 
-    When I run `wp plugin auto-updates status hello --field=status`
+    When I run `wp plugin auto-updates status sample-plugin --field=status`
     Then STDOUT should be:
       """
       enabled
@@ -103,7 +103,7 @@ Feature: Show the status of auto-updates for WordPress plugins
     When I run `wp plugin auto-updates status --all --format=json`
     Then STDOUT should be:
       """
-      [{"name":"akismet","status":"disabled"},{"name":"hello","status":"disabled"},{"name":"duplicate-post","status":"disabled"}]
+      [{"name":"akismet","status":"disabled"},{"name":"sample-plugin","status":"disabled"},{"name":"duplicate-post","status":"disabled"}]
       """
 
     When I run `wp plugin auto-updates status --all --format=csv`
@@ -111,13 +111,13 @@ Feature: Show the status of auto-updates for WordPress plugins
       """
       name,status
       akismet,disabled
-      hello,disabled
+      sample-plugin,disabled
       duplicate-post,disabled
       """
 
   @require-wp-5.5
   Scenario: Handle malformed option value
     When I run `wp option update auto_update_plugins ""`
-    And I try `wp plugin auto-updates status hello`
+    And I try `wp plugin auto-updates status sample-plugin`
     Then the return code should be 0
     And STDERR should be empty

--- a/features/plugin-deactivate.feature
+++ b/features/plugin-deactivate.feature
@@ -2,7 +2,8 @@ Feature: Deactivate WordPress plugins
 
   Background:
     Given a WP install
-    And I run `wp plugin activate akismet hello`
+    And I run `wp plugin install https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip`
+    And I run `wp plugin activate akismet sample-plugin`
 
   Scenario: Deactivate a plugin that's already activated
     When I run `wp plugin deactivate akismet`
@@ -23,7 +24,7 @@ Feature: Deactivate WordPress plugins
     And STDOUT should be empty
     And the return code should be 1
 
-    When I try `wp plugin deactivate akismet hello debug-bar`
+    When I try `wp plugin deactivate akismet sample-plugin debug-bar`
     Then STDERR should be:
       """
       Warning: The 'debug-bar' plugin could not be found.
@@ -32,7 +33,7 @@ Feature: Deactivate WordPress plugins
     And STDOUT should be:
       """
       Plugin 'akismet' deactivated.
-      Plugin 'hello' deactivated.
+      Plugin 'sample-plugin' deactivated.
       """
     And the return code should be 1
 
@@ -78,7 +79,7 @@ Feature: Deactivate WordPress plugins
       """
 
   Scenario: Adding --exclude with plugin deactivate --all should exclude the plugins specified via --exclude
-    When I try `wp plugin deactivate --all --exclude=hello`
+    When I try `wp plugin deactivate --all --exclude=sample-plugin`
     Then STDOUT should be:
       """
       Plugin 'akismet' deactivated.
@@ -87,7 +88,7 @@ Feature: Deactivate WordPress plugins
     And the return code should be 0
 
   Scenario: Adding --exclude with plugin deactivate should throw an error unless --all given
-    When I try `wp plugin deactivate --exclude=hello`
+    When I try `wp plugin deactivate --exclude=sample-plugin`
     Then the return code should be 1
     And STDERR should be:
       """

--- a/features/plugin-delete.feature
+++ b/features/plugin-delete.feature
@@ -2,6 +2,7 @@ Feature: Delete WordPress plugins
 
   Background:
     Given a WP install
+    And I run `wp plugin install https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip`
 
   Scenario: Delete an installed plugin
     When I run `wp plugin delete akismet`
@@ -17,7 +18,7 @@ Feature: Delete WordPress plugins
     Then STDOUT should be:
       """
       Deleted 'akismet' plugin.
-      Deleted 'hello' plugin.
+      Deleted 'sample-plugin' plugin.
       Success: Deleted 2 of 2 plugins.
       """
     And the return code should be 0
@@ -41,7 +42,7 @@ Feature: Delete WordPress plugins
     And the return code should be 0
 
   Scenario: Excluding a plugin from deletion when using --all switch
-    When I try `wp plugin delete --all --exclude=akismet,hello`
+    When I try `wp plugin delete --all --exclude=akismet,sample-plugin`
     Then STDOUT should be:
       """
       Success: No plugins deleted.

--- a/features/plugin-uninstall.feature
+++ b/features/plugin-uninstall.feature
@@ -2,6 +2,7 @@ Feature: Uninstall a WordPress plugin
 
   Background:
     Given a WP install
+    And I run `wp plugin install https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip`
 
   Scenario: Uninstall an installed plugin should uninstall, delete files
     When I run `wp plugin uninstall akismet`
@@ -26,15 +27,15 @@ Feature: Uninstall a WordPress plugin
     And the wp-content/plugins/akismet directory should exist
 
   Scenario: Uninstall a plugin that is not in a folder and has custom name
-    When I run `wp plugin uninstall hello`
+    When I run `wp plugin uninstall sample-plugin`
     Then STDOUT should be:
       """
-      Uninstalled and deleted 'hello' plugin.
+      Uninstalled and deleted 'sample-plugin' plugin.
       Success: Uninstalled 1 of 1 plugins.
       """
     And the return code should be 0
     And STDERR should be empty
-    And the wp-content/plugins/hello.php file should not exist
+    And the wp-content/plugins/sample-plugin.php file should not exist
 
   Scenario: Missing required inputs
     When I try `wp plugin uninstall`
@@ -87,7 +88,7 @@ Feature: Uninstall a WordPress plugin
     Then STDOUT should be:
       """
       Uninstalled and deleted 'akismet' plugin.
-      Uninstalled and deleted 'hello' plugin.
+      Uninstalled and deleted 'sample-plugin' plugin.
       Success: Uninstalled 2 of 2 plugins.
       """
     And the return code should be 0
@@ -111,7 +112,7 @@ Feature: Uninstall a WordPress plugin
     Then STDERR should be:
       """
       Warning: The 'akismet' plugin is active.
-      Warning: The 'hello' plugin is active.
+      Warning: The 'sample-plugin' plugin is active.
       Error: No plugins uninstalled.
       """
     And the return code should be 1
@@ -125,7 +126,7 @@ Feature: Uninstall a WordPress plugin
     And STDERR should be empty
 
   Scenario: Excluding a plugin from uninstallation when using --all switch
-    When I try `wp plugin uninstall --all --exclude=akismet,hello`
+    When I try `wp plugin uninstall --all --exclude=akismet,sample-plugin`
     Then STDOUT should be:
       """
       Success: No plugins uninstalled.

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -301,7 +301,7 @@ Feature: Manage WordPress plugins
   Scenario: List plugins
     Given a WP install
 
-    When I run `wp plugin activate akismet hello`
+    When I run `wp plugin activate akismet`
     Then STDOUT should not be empty
 
     When I run `wp plugin list --status=inactive --field=name`
@@ -348,7 +348,7 @@ Feature: Manage WordPress plugins
       // Network: true
       """
 
-    When I run `wp plugin activate akismet hello`
+    When I run `wp plugin activate akismet`
     Then STDOUT should not be empty
 
     When I run `wp plugin install wordpress-importer --ignore-requirements`
@@ -425,13 +425,17 @@ Feature: Manage WordPress plugins
   @require-mysql
   Scenario: Enable and disable all plugins
     Given a WP install
+    And I run `wp plugin install https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip`
 
     When I run `wp plugin activate --all`
     Then STDOUT should contain:
       """
       Plugin 'akismet' activated.
-      Plugin 'hello' activated.
-      Success: Activated 2 of 2 plugins.
+      Plugin 'sample-plugin' activated.
+      """
+    And STDOUT should not contain:
+      """
+      Success: Activated 3 of 3 plugins.
       """
 
     When I run `wp plugin activate --all`
@@ -450,11 +454,14 @@ Feature: Manage WordPress plugins
       """
 
     When I run `wp plugin deactivate --all`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       Plugin 'akismet' deactivated.
-      Plugin 'hello' deactivated.
-      Success: Deactivated 2 of 2 plugins.
+      Plugin 'sample-plugin' deactivated.
+      """
+    And STDOUT should not contain:
+      """
+      Success: Deactivated 3 of 3 plugins.
       """
 
     When I run `wp plugin deactivate --all`
@@ -653,7 +660,7 @@ Feature: Manage WordPress plugins
   Scenario: Validate installed plugin's version.
     Given a WP installation
     And I run `wp plugin uninstall --all`
-    And I run `wp plugin install hello-dolly`
+    And I run `wp plugin install hello-dolly --force`
     And a wp-content/mu-plugins/test-plugin-update.php file:
       """
       <?php
@@ -739,16 +746,17 @@ Feature: Manage WordPress plugins
   @require-wp-5.5
   Scenario: Listing plugins should include name and auto_update
     Given a WP install
+    And I run `wp plugin install https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip`
     When I run `wp plugin list --fields=name,auto_update`
     Then STDOUT should be a table containing rows:
       | name              | auto_update          |
-      | hello             | off                  |
+      | sample-plugin     | off                  |
 
-    When I run `wp plugin auto-updates enable hello`
+    When I run `wp plugin auto-updates enable sample-plugin`
     And I try `wp plugin list --fields=name,auto_update`
     Then STDOUT should be a table containing rows:
       | name              | auto_update          |
-      | hello             | on                   |
+      | sample-plugin     | on                   |
 
   Scenario: Listing plugins should include tested_up_to from the 'tested up to' header
     Given a WP install


### PR DESCRIPTION
Hello Dolly was moved from a single file to a directory in WordPress 6.9.