### PR TITLE
Harden `check-update` test

### DIFF
--- a/features/plugin-check-update.feature
+++ b/features/plugin-check-update.feature
@@ -4,7 +4,7 @@ Feature: Check for plugin updates
   Scenario: Check for plugin updates with no updates available
     Given a WP install
 
-    # In case the bundled Akismet has newer version
+    # In case Akismet has a newer release than the bundled version
     When I run `wp plugin update --all`
     And I run `wp plugin install wordpress-importer --activate`
     Then STDOUT should not be empty

--- a/features/plugin-check-update.feature
+++ b/features/plugin-check-update.feature
@@ -4,7 +4,9 @@ Feature: Check for plugin updates
   Scenario: Check for plugin updates with no updates available
     Given a WP install
 
-    When I run `wp plugin install wordpress-importer --activate`
+    # In case the bundled Akismet has newer version
+    When I run `wp plugin update --all`
+    And I run `wp plugin install wordpress-importer --activate`
     Then STDOUT should not be empty
 
     When I run `wp plugin check-update --all`


### PR DESCRIPTION
When Akismet has a new release but the bundled WP doesn't include it yet, this test is failing until there's a new WP release. For the purpose of this test, we can simply update all plugins before checking for updates.