### PR TITLE
Fix Plugin name with HTML entities test

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -481,10 +481,10 @@ Feature: Manage WordPress plugins
   Scenario: Plugin name with HTML entities
     Given a WP install
 
-    When I run `wp plugin install debug-bar-list-dependencies`
+    When I run `wp plugin install health-check`
     Then STDOUT should contain:
       """
-      Installing Debug Bar List Script & Style Dependencies
+      Installing Health Check & Troubleshooting
       """
 
   # Not running for SQLite because it involves another must-use plugin and a drop-in.


### PR DESCRIPTION
The debug-bar-list-dependencies plugin was closed the other day, so switching to the Health Check plugin which will hopefully be around for a while.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
