### PR TITLE
Fix change --path parameter to --target-path parameter to avoid clashing with global parameter

### DIFF
--- a/features/extension-download.feature
+++ b/features/extension-download.feature
@@ -19,7 +19,7 @@ Feature: Download WordPress.org extensions without loading WordPress
   Scenario: Downloading a plugin package to a custom path
     Given an empty directory
 
-    When I run `wp plugin download debug-bar --path=/tmp/wp-cli-download-test-plugin`
+    When I run `wp plugin download debug-bar --target-path=/tmp/wp-cli-download-test-plugin`
     Then STDOUT should contain:
       """
       Success: Downloaded plugin package to
@@ -103,7 +103,7 @@ Feature: Download WordPress.org extensions without loading WordPress
   Scenario: Downloading a theme package to a custom path
     Given an empty directory
 
-    When I run `wp theme download twentytwelve --path=/tmp/wp-cli-download-test-theme`
+    When I run `wp theme download twentytwelve --target-path=/tmp/wp-cli-download-test-theme`
     Then STDOUT should contain:
       """
       Success: Downloaded theme package to

--- a/src/Plugin_Download_Command.php
+++ b/src/Plugin_Download_Command.php
@@ -11,7 +11,7 @@ use WP_CLI\WpOrgApi;
  * <slug>
  * : Slug of the plugin to download.
  *
- * [--path=<path>]
+ * [--target-path=<path>]
  * : Directory to store the downloaded zip file. Defaults to the current directory.
  *
  * [--version=<version>]
@@ -38,7 +38,7 @@ class Plugin_Download_Command {
 	 * Downloads a plugin zip package without loading WordPress.
 	 *
 	 * @param array{0: string}                                   $args       Positional arguments.
-	 * @param array{path?: string, version?: string, force?: bool, insecure?: bool} $assoc_args Associative arguments.
+	 * @param array{target-path?: string, version?: string, force?: bool, insecure?: bool} $assoc_args Associative arguments.
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		$slug = (string) $args[0];
@@ -49,7 +49,7 @@ class Plugin_Download_Command {
 		$insecure     = Utils\get_flag_value( $assoc_args, 'insecure', false );
 		$force        = Utils\get_flag_value( $assoc_args, 'force', false );
 		$requested    = Utils\get_flag_value( $assoc_args, 'version', null );
-		$download_dir = Utils\get_flag_value( $assoc_args, 'path', getcwd() );
+		$download_dir = Utils\get_flag_value( $assoc_args, 'target-path', getcwd() );
 
 		if ( ! is_dir( $download_dir ) ) {
 			if ( ! @mkdir( $download_dir, 0755, true ) ) {

--- a/src/Theme_Download_Command.php
+++ b/src/Theme_Download_Command.php
@@ -11,7 +11,7 @@ use WP_CLI\WpOrgApi;
  * <slug>
  * : Slug of the theme to download.
  *
- * [--path=<path>]
+ * [--target-path=<path>]
  * : Directory to store the downloaded zip file. Defaults to the current directory.
  *
  * [--version=<version>]
@@ -38,7 +38,7 @@ class Theme_Download_Command {
 	 * Downloads a theme zip package without loading WordPress.
 	 *
 	 * @param array{0: string}                                   $args       Positional arguments.
-	 * @param array{path?: string, version?: string, force?: bool, insecure?: bool} $assoc_args Associative arguments.
+	 * @param array{target-path?: string, version?: string, force?: bool, insecure?: bool} $assoc_args Associative arguments.
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		$slug = (string) $args[0];
@@ -49,7 +49,7 @@ class Theme_Download_Command {
 		$insecure     = Utils\get_flag_value( $assoc_args, 'insecure', false );
 		$force        = Utils\get_flag_value( $assoc_args, 'force', false );
 		$requested    = Utils\get_flag_value( $assoc_args, 'version', null );
-		$download_dir = Utils\get_flag_value( $assoc_args, 'path', getcwd() );
+		$download_dir = Utils\get_flag_value( $assoc_args, 'target-path', getcwd() );
 
 		if ( ! is_dir( $download_dir ) ) {
 			if ( ! @mkdir( $download_dir, 0755, true ) ) {


### PR DESCRIPTION
Adds to https://github.com/wp-cli/extension-command/pull/527

https://make.wordpress.org/cli/handbook/references/config/

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
