### PR TITLE
Fix WordPress requirement check for unavailable plugin updates

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -1033,6 +1033,56 @@ Feature: Manage WordPress plugins
 
 
   @require-wp-4.0
+  Scenario: Do not report a WordPress requirement when the installed version already meets the update's requirement
+    Given a WP install
+    And a wp-content/plugins/example/example.php file:
+      """
+      <?php
+        /**
+        * Plugin Name: Example Plugin
+        * Version: 1.0.0
+        * Requires at least: 3.7
+        * Tested up to: 6.7
+      """
+    And that HTTP requests to https://api.wordpress.org/plugins/update-check/1.1/ will respond with:
+      """
+      HTTP/1.1 200 OK
+
+      {
+        "plugins": [],
+        "translations": [],
+        "no_update": {
+          "example/example.php": {
+            "id": "w.org/plugins/example",
+            "slug": "example",
+            "plugin": "example/example.php",
+            "new_version": "2.0.0",
+
+            "requires": "4.0",
+            "requires_php": "5.6",
+            "requires_plugins": [],
+            "compatibility": []
+          }
+        }
+      }
+      """
+
+    When I run `wp plugin list`
+    Then STDOUT should be a table containing rows:
+      | name            | status   | update       | version  | update_version   | auto_update | requires   | requires_php   |
+      | example         | inactive | unavailable  | 1.0.0    | 2.0.0            | off         | 4.0        | 5.6            |
+
+    When I try `wp plugin update example`
+    Then STDERR should contain:
+      """
+      Warning: example: Update file not provided. Contact author for more details
+      """
+    And STDERR should not contain:
+      """
+      This update requires WordPress version
+      """
+
+  @require-wp-4.0
   Scenario: Show plugin update as unavailable if it doesn't meet PHP requirements
     Given a WP install
     And a wp-content/plugins/example/example.php file:

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1049,7 +1049,7 @@ class Plugin_Command extends CommandWithUpgrade {
 					$items[ $file ]['requires']       = isset( $plugin_update_info->requires ) ? $plugin_update_info->requires : null;
 					$items[ $file ]['requires_php']   = isset( $plugin_update_info->requires_php ) ? $plugin_update_info->requires_php : null;
 
-					if ( isset( $plugin_update_info->requires ) && version_compare( $wp_version, $requires, '>=' ) ) {
+					if ( isset( $plugin_update_info->requires ) && version_compare( $wp_version, $plugin_update_info->requires, '<' ) ) {
 						$reason = "This update requires WordPress version $plugin_update_info->requires, but the version installed is $wp_version.";
 					} elseif ( ! isset( $plugin_update_info->package ) ) {
 						$reason = 'Update file not provided. Contact author for more details';


### PR DESCRIPTION
## Description

When a plugin update appears in the update API's `no_update` list with a newer version than the installed copy, `Plugin_Command::get_item_list()` computes the `update_unavailable_reason` that `wp plugin update` and `wp plugin list` surface. The WordPress-version branch had two problems:

1. It compared the running WordPress version against `$requires`, but by that point `$requires` has been reassigned to the *installed plugin's own* "Requires at least" header (the display fallback a few lines above), not the update's required version (`$plugin_update_info->requires`).
2. It used `>=` (requirement met) to gate the "requirement not met" message.

The net effect: the message *"This update requires WordPress version X, but the version installed is Y"* was shown whenever the site met the plugin's own minimum — almost always true — so updates that are unavailable for other reasons (for example paid plugins served via `no_update`) reported a nonsensical WordPress-version reason (Y ≥ X). Conversely, when a plugin's own header exceeded the running WordPress version, the genuine reason was suppressed.

This compares the running WordPress version against the update's own `requires` value using `<`, matching the behavior already implemented correctly for themes in `ParseThemeNameInput::get_all_items()`.

Introduced in #440.

## How to reproduce

Install a plugin, then have the update-check API return the plugin in `no_update` with a newer `new_version` and a `requires` value the site satisfies. `wp plugin update <slug>` warns *"This update requires WordPress version …"* even though the installed version meets that requirement.

## Testing

Adds a Behat scenario in `features/plugin.feature` asserting the WordPress-requirement reason is not emitted when the site already meets the update's `requires`. PHPStan (level 9) and PHPCS pass. (No standalone PHPUnit exists for command logic; the repo covers this via Behat, which needs a live WP install.)

---
Disclosure: prepared with assistance from Claude (Anthropic); reviewed and verified before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved messaging for unavailable plugin updates with version requirements.
  * WordPress version warnings now appear only when the installed version does not meet an update’s requirements.
  * Plugin listings continue to show relevant WordPress and PHP requirements for unavailable updates.
  * Updates requiring unavailable packages now report the package warning without displaying misleading WordPress-version warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->