### PR TITLE
Deprecate `plugin status` and `theme status` commands

### DIFF
--- a/features/plugin-status.feature
+++ b/features/plugin-status.feature
@@ -8,7 +8,7 @@ Feature: List the status of plugins
       <?php
       """
 
-    When I run `wp plugin status`
+    When I try `wp plugin status`
     Then STDOUT should contain:
       """
       D db-error.php
@@ -17,4 +17,13 @@ Feature: List the status of plugins
       """
       D = Drop-In
       """
-    And STDERR should be empty
+
+  Scenario: Plugin status command is deprecated
+    Given a WP install
+
+    When I try `wp plugin status`
+    Then STDERR should contain:
+      """
+      Warning: The `plugin status` command is deprecated. Use `wp plugin list` or `wp plugin get <plugin>` instead.
+      """
+    And the return code should be 0

--- a/features/plugin-uninstall.feature
+++ b/features/plugin-uninstall.feature
@@ -186,7 +186,7 @@ Feature: Uninstall a WordPress plugin
   Scenario: Uninstalling a plugin should remove its update info
     Given a WP install
     And I run `wp plugin install wordpress-importer --version=0.6`
-    And I run `wp plugin status wordpress-importer`
+    And I try `wp plugin status wordpress-importer`
 
     And I run `wp transient get --network update_plugins`
     Then STDOUT should contain:

--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -60,7 +60,7 @@ Feature: Update WordPress plugins
       package from https://downloads.wordpress.org/plugin/wordpress-importer.0.5.zip...
       """
 
-    When I run `wp plugin status wordpress-importer`
+    When I try `wp plugin status wordpress-importer`
     Then STDOUT should contain:
       """
       Update available
@@ -72,7 +72,7 @@ Feature: Update WordPress plugins
       wordpress-importer
       """
 
-    When I run `wp plugin status wordpress-importer`
+    When I try `wp plugin status wordpress-importer`
     Then STDOUT should contain:
       """
       Update available

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -38,7 +38,7 @@ Feature: Manage WordPress plugins
 
     # Check that the inner-plugin is not picked up
     When I run `mv {PLUGIN_DIR}/plugin1 {PLUGIN_DIR}/Zombieland/`
-    And I run `wp plugin status Zombieland`
+    And I try `wp plugin status Zombieland`
     Then STDOUT should contain:
       """
       Plugin Zombieland details:
@@ -52,13 +52,13 @@ Feature: Manage WordPress plugins
     When I run `wp plugin activate Zombieland`
     Then STDOUT should not be empty
 
-    When I run `wp plugin status Zombieland`
+    When I try `wp plugin status Zombieland`
     Then STDOUT should contain:
       """
           Status: Active
       """
 
-    When I run `wp plugin status`
+    When I try `wp plugin status`
     Then STDOUT should not be empty
 
     When I run `wp plugin list --fields=name,status,update,version,update_version,auto_update`
@@ -198,7 +198,7 @@ Feature: Manage WordPress plugins
       Success: Activated 1 of 1 plugins.
       """
 
-    When I run `wp plugin status network-only`
+    When I try `wp plugin status network-only`
     Then STDOUT should contain:
       """
           Status: Active
@@ -220,7 +220,7 @@ Feature: Manage WordPress plugins
       Success: Activated 1 of 1 plugins.
       """
 
-    When I run `wp plugin status network-only`
+    When I try `wp plugin status network-only`
     Then STDOUT should contain:
       """
           Status: Network Active

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -315,6 +315,7 @@ Feature: Manage WordPress themes
     When I try `wp theme status myth`
     Then STDERR should be:
       """
+      Warning: The `theme status` command is deprecated. Use `wp theme list` or `wp theme get <theme>` instead.
       Error: Stylesheet is missing.
       """
     And STDOUT should be empty

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -1,5 +1,15 @@
 Feature: Manage WordPress themes
 
+  Scenario: Theme status command is deprecated
+    Given a WP install
+
+    When I try `wp theme status`
+    Then STDERR should contain:
+      """
+      Warning: The `theme status` command is deprecated. Use `wp theme list` or `wp theme get <theme>` instead.
+      """
+    And the return code should be 0
+
   Scenario: Installing and deleting theme
     Given a WP install
     And I run `wp theme delete --all --force`
@@ -8,7 +18,7 @@ Feature: Manage WordPress themes
     When I run `wp theme install twentytwelve`
     Then STDOUT should not be empty
 
-    When I run `wp theme status twentytwelve`
+    When I try `wp theme status twentytwelve`
     Then STDOUT should contain:
       """
       Theme twentytwelve details:
@@ -64,7 +74,7 @@ Feature: Manage WordPress themes
 
     When I run `wp theme install classic --activate`
     And I run `wp theme list --field=name --status=inactive | xargs wp theme delete`
-    And I run `wp theme status`
+    And I try `wp theme status`
     Then STDOUT should be:
       """
       1 installed theme:
@@ -155,7 +165,7 @@ Feature: Manage WordPress themes
       Success: Deleted
       """
 
-    When I run `wp theme status twentytwelve`
+    When I try `wp theme status twentytwelve`
     Then STDOUT should contain:
       """
       Update available
@@ -167,7 +177,7 @@ Feature: Manage WordPress themes
       twentytwelve
       """
 
-    When I run `wp theme status twentytwelve`
+    When I try `wp theme status twentytwelve`
     Then STDOUT should contain:
       """
       Update available
@@ -558,12 +568,15 @@ Feature: Manage WordPress themes
       This theme requires a parent theme. Checking if it is installed
       """
 
-    When I run `wp theme status moina`
+    When I try `wp theme status moina`
     Then STDOUT should contain:
       """
       Theme moina details:
       """
-    And STDERR should be empty
+    And STDERR should contain:
+      """
+      Warning: The `theme status` command is deprecated. Use `wp theme list` or `wp theme get <theme>` instead.
+      """
 
   Scenario: Get status field in theme detail
     Given a WP install

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -75,13 +75,13 @@ Feature: Manage WordPress themes and plugins
       ["<item>"]
       """
 
-    When I run `wp <type> status`
+    When I try `wp <type> status`
     Then STDOUT should contain:
       """
       U = Update Available
       """
 
-    When I run `wp <type> status <item>`
+    When I try `wp <type> status <item>`
     Then STDOUT should contain:
       """
           Status: Inactive
@@ -104,7 +104,7 @@ Feature: Manage WordPress themes and plugins
       updated
       """
 
-    When I run `wp <type> status <item>`
+    When I try `wp <type> status <item>`
     Then STDOUT should not contain:
       """
       (Update available)

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -109,6 +109,8 @@ class Plugin_Command extends CommandWithUpgrade {
 	 *         Version: 20160523.1
 	 *         Author: Otto42, pross
 	 *         Description: A simple and easy way to test your theme for all the latest WordPress standards and practices. A great theme development tool!
+	 *
+	 * @deprecated Use `wp plugin list` or `wp plugin get <plugin>` instead.
 	 */
 	public function status( $args ) {
 		parent::status( $args );

--- a/src/Theme_Command.php
+++ b/src/Theme_Command.php
@@ -96,6 +96,8 @@ class Theme_Command extends CommandWithUpgrade {
 	 *          Status: Inactive
 	 *          Version: 1.2
 	 *          Author: the WordPress team
+	 *
+	 * @deprecated Use `wp theme list` or `wp theme get <theme>` instead.
 	 */
 	public function status( $args ) {
 		if ( isset( $args[0] ) ) {


### PR DESCRIPTION
## What

Deprecates `wp plugin status` and `wp theme status`, pointing users at the
scriptable `list` / `get` commands. The commands keep working and now emit a
deprecation warning before running; removal is planned for WP-CLI 4.0.

Implements decision Q7 of the v3.0.0 breaking-change triage: deprecate in 3.0,
remove in 4.0.

## How

- Add the declarative `@deprecated` docblock tag (wp-cli/wp-cli#6343) to
  `Plugin_Command::status()` and `Theme_Command::status()`. No hand-rolled
  `WP_CLI::warning()`; the framework surfaces the notice at runtime and in
  `wp help`.
- Replacements: `status` (all) -> `list`, `status <name>` (one) -> `get <name>`.

## Tests

A deprecated command writes its warning to STDERR on every call, which the test
harness treats as a failure under `When I run`. Scripted `status` invocations
move to `When I try`, and two scenarios assert the warning text and a zero exit
code.

## Notes

- Additive / non-breaking in 3.0: the command still runs and exits 0. The
  `@deprecated` tag is inert on frameworks without wp-cli/wp-cli#6343, so it
  only surfaces under WP-CLI 3.0.
- `plugin auto-updates status` and `theme auto-updates status` are separate
  commands and are untouched.
- README regeneration is left to the `regenerate-readme` workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Deprecated `wp plugin status`; use `wp plugin list` or `wp plugin get <plugin>` instead.
  * Deprecated `wp theme status`; use `wp theme list` or `wp theme get <theme>` instead.
* **Bug Fixes**
  * Updated status command behavior to report deprecation warnings while preserving successful exit codes.
  * Improved status checks for plugins, themes, drop-ins, multisite installations, and update scenarios.
  * Status output continues to display relevant details, including active states, available updates, and theme errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->