### PR TITLE
Treat older plugin no-update versions as up to date

### DIFF
--- a/features/plugin-update.feature
+++ b/features/plugin-update.feature
@@ -240,7 +240,7 @@ Feature: Update WordPress plugins
 
   # Skipped on Windows because of sed usage that would need to be refactored for compatibility.
   @require-wp-5.2 @skip-windows
-  Scenario: Updating all plugins with some of them having an invalid version shouldn't report an error
+  Scenario: Updating all plugins ignores an older no-update version
     Given a WP install
     And I run `wp plugin delete akismet`
 
@@ -254,20 +254,11 @@ Feature: Update WordPress plugins
     Then STDOUT should be empty
     And the return code should be 0
 
-    When I try `wp plugin update --all`
-    Then STDERR should contain:
-      """
-      Warning: health-check: version higher than expected.
-      """
-
-    And STDOUT should not contain:
-      """
-      Error: Only updated 1 of 1 plugins.
-      """
-
+    When I run `wp plugin update --all`
+    Then STDERR should be empty
     And STDOUT should contain:
       """
-      Success: Updated 1 of 1 plugins (1 skipped).
+      Success: Updated 1 of 1 plugins.
       """
 
   # Tests for --auto-update-indicated feature

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -731,56 +731,58 @@ Feature: Manage WordPress plugins
       | db-error.php |       | Custom database error message. | db-error.php |
 
   @require-wp-4.0
-  Scenario: Validate installed plugin's version.
-    Given a WP installation
-    And I run `wp plugin uninstall --all`
-    And I run `wp plugin install hello-dolly --force`
-    And a wp-content/mu-plugins/test-plugin-update.php file:
+  Scenario Outline: Treat an older or empty no-update version as up to date
+    Given a WP install
+    And a wp-content/plugins/example/example.php file:
       """
       <?php
       /**
-       * Plugin Name: Test Plugin Update
-       * Description: Fakes installed plugin's data to verify plugin version mismatch
-       * Author: WP-CLI tests
+       * Plugin Name: Example Plugin
+       * Version: 2.0.0
        */
-
-      add_filter( 'site_transient_update_plugins', function( $value ) {
-          if ( ! is_object( $value ) ) {
-              return $value;
-          }
-
-          unset( $value->response['hello-dolly/hello.php'] );
-          $value->no_update['hello-dolly/hello.php']->new_version = '1.5';
-
-          return $value;
-      } );
-      ?>
       """
+    And that HTTP requests to https://api.wordpress.org/plugins/update-check/1.1/ will respond with:
+      """
+      HTTP/1.1 200 OK
 
-    When I run `wp plugin list --name=hello-dolly  --field=version`
-    Then save STDOUT as {PLUGIN_VERSION}
-
-    When I run `wp plugin list --name=hello-dolly  --field=update_version`
-    Then save STDOUT as {UPDATE_VERSION}
+      {
+        "plugins": [],
+        "translations": [],
+        "no_update": {
+          "example/example.php": {
+            "id": "vendor.example/plugins/example",
+            "slug": "example",
+            "plugin": "example/example.php",
+            "new_version": "<upstream_version>",
+            "package": ""
+          }
+        }
+      }
+      """
 
     When I run `wp plugin list`
     Then STDOUT should be a table containing rows:
-      | name               | status   | update                       | version          | update_version   | auto_update |
-      | hello-dolly        | inactive | version higher than expected | {PLUGIN_VERSION} | {UPDATE_VERSION} | off         |
+      | name    | status   | update | version | update_version | auto_update |
+      | example | inactive | none   | 2.0.0   |                | off         |
 
-    When I try `wp plugin update --all`
-    Then STDERR should be:
+    When I run `wp plugin update --all`
+    Then STDOUT should be:
       """
-      Warning: hello-dolly: version higher than expected.
-      Error: No plugins updated.
+      Success: Plugin already updated.
       """
+    And STDERR should be empty
 
-    When I try `wp plugin update hello-dolly`
-    Then STDERR should be:
+    When I run `wp plugin update example`
+    Then STDOUT should be:
       """
-      Warning: hello-dolly: version higher than expected.
-      Error: No plugins updated.
+      Success: Plugin already updated.
       """
+    And STDERR should be empty
+
+    Examples:
+      | upstream_version |
+      | 1.0.0            |
+      |                  |
 
   Scenario: Only valid status filters are accepted when listing plugins
     Given a WP install

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1033,13 +1033,6 @@ class Plugin_Command extends CommandWithUpgrade {
 				// Get info for all plugins that don't have an update.
 				$plugin_update_info = isset( $all_update_info->no_update[ $file ] ) ? $all_update_info->no_update[ $file ] : null;
 
-				// Check if local version is newer than what is listed upstream.
-				if ( null !== $plugin_update_info && version_compare( $details['Version'], $plugin_update_info->new_version, '>' ) ) {
-					$items[ $file ]['update']       = static::INVALID_VERSION_MESSAGE;
-					$items[ $file ]['requires']     = isset( $plugin_update_info->requires ) ? $plugin_update_info->requires : null;
-					$items[ $file ]['requires_php'] = isset( $plugin_update_info->requires_php ) ? $plugin_update_info->requires_php : null;
-				}
-
 				// If there is a plugin in no_update with a newer version than the local copy, it is either because:
 				// A: the plugins update API has already filtered it because the local WordPress version is too low
 				// B: It is possibly a paid plugin that has an update which the user does not qualify for


### PR DESCRIPTION
## Problem

WordPress separates plugin update data into `response` (an update is available) and `no_update` (the plugin was checked, but no update is available).

WP-CLI additionally compared the installed plugin version with `new_version` for entries in `no_update`. When the installed version was higher, it changed the status to `version higher than expected`. `wp plugin update` then treated the plugin as skipped and could return an error even though WordPress considered it up to date.

This is observable with third-party update providers. The latest report in wp-cli/wp-cli#5320 points to Kadence Blocks 3.7.6 and its Harbor-backed legacy license update flow. Harbor may place an older or empty catalog version in `no_update`; both values trigger WP-CLI's special case. The execution context cannot resolve this because the transient has already been populated.

## Solution

Keep the normal `none` status for plugin entries in `no_update` when their upstream version is older or empty. This matches WordPress Core, which only considers entries in `response` updateable.

This does not restore the old false-positive "Updated" result: items with `update: none` are excluded before the upgrader runs. The existing handling for a newer version in `no_update` remains unchanged, as that represents an unavailable update due to requirements or missing package access.

## Tests

- Replace the previous warning-oriented scenario with a deterministic outline covering both an older and an empty `new_version`.
- Assert that listing reports `none`, and both bulk and single-plugin updates return the normal "already updated" success.
- Keep the mixed-update case to verify that another eligible plugin is still updated without a warning or skipped count.

Fixes wp-cli/wp-cli#5320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin update handling when WordPress reports an older or empty available version.
  - Plugins are now correctly shown as up to date instead of displaying misleading version mismatch warnings.
  - Updating all plugins or an individual plugin now reports a successful “already updated” result without unnecessary error output.
  - Plugin updates with valid newer versions continue to be identified as unavailable when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->