### PR TITLE
Modernize deprecated syntax in Behat tests

### DIFF
--- a/features/plugin-uninstall.feature
+++ b/features/plugin-uninstall.feature
@@ -160,7 +160,7 @@ Feature: Uninstall a WordPress plugin
   Scenario: Uninstalling a plugin should remove its language pack
     Given a WP install
     And I run `wp plugin install wordpress-importer`
-    And I run `wp core language install fr_FR`
+    And I run `wp language core install fr_FR`
     And I run `wp site switch-language fr_FR`
 
     When I run `wp language plugin install wordpress-importer fr_FR`

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -5,7 +5,7 @@ Feature: Manage WordPress plugins
     And I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
 
-    When I run `wp plugin scaffold --skip-tests plugin1`
+    When I run `wp scaffold plugin --skip-tests plugin1`
     Then STDOUT should not be empty
     And the {PLUGIN_DIR}/plugin1/plugin1.php file should exist
     And the {PLUGIN_DIR}/zombieland/phpunit.xml.dist file should not exist
@@ -22,7 +22,7 @@ Feature: Manage WordPress plugins
       {PLUGIN_DIR}/plugin1
       """
 
-    When I run `wp plugin scaffold Zombieland`
+    When I run `wp scaffold plugin Zombieland`
     Then STDOUT should not be empty
     And the {PLUGIN_DIR}/Zombieland/Zombieland.php file should exist
     And the {PLUGIN_DIR}/Zombieland/phpunit.xml.dist file should exist

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -359,7 +359,7 @@ Feature: Manage WordPress themes
       """
 
     # Hybrid_Registry throws warning for PHP 8+.
-    When I try `wp network-meta get 1 allowedthemes`
+    When I try `wp network meta get 1 allowedthemes`
     Then STDOUT should not contain:
       """
       'moina-blog' => true
@@ -373,7 +373,7 @@ Feature: Manage WordPress themes
       """
 
     # Hybrid_Registry throws warning for PHP 8+.
-    When I try `wp network-meta get 1 allowedthemes`
+    When I try `wp network meta get 1 allowedthemes`
     Then STDOUT should contain:
       """
       'moina-blog' => true
@@ -387,7 +387,7 @@ Feature: Manage WordPress themes
       """
 
     # Hybrid_Registry throws warning for PHP 8+.
-    When I try `wp network-meta get 1 allowedthemes`
+    When I try `wp network meta get 1 allowedthemes`
     Then STDOUT should not contain:
       """
       'moina-blog' => true


### PR DESCRIPTION
## What

Updates the Behat tests to use the current command syntax instead of forms deprecated by wp-cli/wp-cli#6356.

## Why

The framework now emits a deprecation warning to STDERR when it rewrites these legacy forms. This breaks `When I run` steps, which expect STDERR to remain empty.

## Tests

- Static and unit test stages from `composer test`
- Changed Behat scenarios
- `composer behat` passed 272 of 277 scenarios; the remaining failures involve stale temporary download artifacts or live GitHub API/auth responses
