### PR TITLE
Fix failing theme tests

### DIFF
--- a/features/theme-delete.feature
+++ b/features/theme-delete.feature
@@ -58,16 +58,16 @@ Feature: Delete WordPress themes
 
   Scenario: Delete all installed themes when active theme has a parent
     Given a WP install
-    And I run `wp theme install moina-blog --activate`
+    And I run `wp theme install oceanly-green --activate`
 
     When I run `wp theme list --field=name`
     Then STDOUT should contain:
       """
-      moina-blog
-      moina
+      oceanly-green
+      oceanly
       """
 
-    When I try `wp theme delete moina-blog`
+    When I try `wp theme delete oceanly-green`
     Then STDERR should contain:
       """
       Can't delete the currently active theme
@@ -77,7 +77,7 @@ Feature: Delete WordPress themes
       Error: No themes deleted.
       """
 
-    When I try `wp theme delete moina`
+    When I try `wp theme delete oceanly`
     Then STDERR should contain:
       """
       Can't delete the parent of the currently active theme
@@ -96,8 +96,8 @@ Feature: Delete WordPress themes
     When I run `wp theme list --field=name`
     Then STDOUT should contain:
       """
-      moina-blog
-      moina
+      oceanly-green
+      oceanly
       """
 
     When I run `wp theme delete --all --force`

--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -59,7 +59,7 @@ Feature: Install WordPress themes
     Given a WP install
     And an empty cache
 
-    When I run `wp theme install moina`
+    When I run `wp theme install oceanly`
     Then STDOUT should contain:
       """
       Success: Installed 1 of 1 themes.
@@ -69,13 +69,13 @@ Feature: Install WordPress themes
       Using cached file
       """
 
-    When I run `wp theme uninstall moina`
+    When I run `wp theme uninstall oceanly`
     Then STDOUT should contain:
       """
       Success: Deleted 1 of 1 themes.
       """
 
-    When I run `wp theme install moina-blog`
+    When I run `wp theme install oceanly-green`
     Then STDOUT should contain:
       """
       Success: Installed 1 of 1 themes.

--- a/features/theme-update.feature
+++ b/features/theme-update.feature
@@ -50,7 +50,7 @@ Feature: Update WordPress themes
       """
 
     # One theme installed.
-    Given I run `wp theme install moina --version=1.0.2`
+    Given I run `wp theme install oceanly --version=1.0.0`
 
     When I try `wp theme update`
     Then the return code should be 1
@@ -241,7 +241,7 @@ Feature: Update WordPress themes
     Given a WP install
     And I run `wp theme delete --all --force`
 
-    When I run `wp theme install moina --version=1.0.2`
+    When I run `wp theme install oceanly --version=1.0.0`
     Then STDOUT should not be empty
 
     When I run `wp theme install twentytwelve --version=1.0`
@@ -250,7 +250,7 @@ Feature: Update WordPress themes
     When I try `wp theme update --all`
     Then STDOUT should contain:
       """
-      Updating Moina...
+      Updating Oceanly...
       """
 
     And STDOUT should contain:

--- a/features/theme-update.feature
+++ b/features/theme-update.feature
@@ -50,7 +50,7 @@ Feature: Update WordPress themes
       """
 
     # One theme installed.
-    Given I run `wp theme install oceanly --version=1.0.0`
+    Given I run `wp theme install storefront --version=1.0.0`
 
     When I try `wp theme update`
     Then the return code should be 1
@@ -241,7 +241,7 @@ Feature: Update WordPress themes
     Given a WP install
     And I run `wp theme delete --all --force`
 
-    When I run `wp theme install oceanly --version=1.0.0`
+    When I run `wp theme install storefront --version=1.0.0`
     Then STDOUT should not be empty
 
     When I run `wp theme install twentytwelve --version=1.0`
@@ -250,7 +250,7 @@ Feature: Update WordPress themes
     When I try `wp theme update --all`
     Then STDOUT should contain:
       """
-      Updating Oceanly...
+      Updating Storefront...
       """
 
     And STDOUT should contain:

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -330,78 +330,78 @@ Feature: Manage WordPress themes
   @require-wp-5.7
   Scenario: Enabling and disabling a theme
     Given a WP multisite install
-    And I run `wp theme install moina`
-    And I run `wp theme install moina-blog`
+    And I run `wp theme install oceanly`
+    And I run `wp theme install oceanly-green`
 
     When I try `wp option get allowedthemes`
     Then the return code should be 1
     # STDERR may or may not be empty, depending on WP-CLI version.
     And STDOUT should be empty
 
-    When I run `wp theme enable moina-blog`
+    When I run `wp theme enable oceanly-green`
     Then STDOUT should contain:
       """
-      Success: Enabled the 'Moina Blog' theme.
+      Success: Enabled the 'Oceanly Green' theme.
       """
 
     When I run `wp option get allowedthemes`
     Then STDOUT should contain:
       """
-      'moina-blog' => true
+      'oceanly-green' => true
       """
 
-    When I run `wp theme disable moina-blog`
+    When I run `wp theme disable oceanly-green`
     Then STDOUT should contain:
       """
-      Success: Disabled the 'Moina Blog' theme.
+      Success: Disabled the 'Oceanly Green' theme.
       """
 
     When I run `wp option get allowedthemes`
     Then STDOUT should not contain:
       """
-      'moina-blog' => true
+      'oceanly-green' => true
       """
 
-    When I run `wp theme enable moina-blog --activate`
+    When I run `wp theme enable oceanly-green --activate`
     Then STDOUT should contain:
       """
-      Success: Enabled the 'Moina Blog' theme.
-      Success: Switched to 'Moina Blog' theme.
+      Success: Enabled the 'Oceanly Green' theme.
+      Success: Switched to 'Oceanly Green' theme.
       """
 
     # Hybrid_Registry throws warning for PHP 8+.
     When I try `wp network meta get 1 allowedthemes`
     Then STDOUT should not contain:
       """
-      'moina-blog' => true
+      'oceanly-green' => true
       """
 
     # Hybrid_Registry throws warning for PHP 8+.
-    When I try `wp theme enable moina-blog --network`
+    When I try `wp theme enable oceanly-green --network`
     Then STDOUT should contain:
       """
-      Success: Network enabled the 'Moina Blog' theme.
+      Success: Network enabled the 'Oceanly Green' theme.
       """
 
     # Hybrid_Registry throws warning for PHP 8+.
     When I try `wp network meta get 1 allowedthemes`
     Then STDOUT should contain:
       """
-      'moina-blog' => true
+      'oceanly-green' => true
       """
 
     # Hybrid_Registry throws warning for PHP 8+.
-    When I try `wp theme disable moina-blog --network`
+    When I try `wp theme disable oceanly-green --network`
     Then STDOUT should contain:
       """
-      Success: Network disabled the 'Moina Blog' theme.
+      Success: Network disabled the 'Oceanly Green' theme.
       """
 
     # Hybrid_Registry throws warning for PHP 8+.
     When I try `wp network meta get 1 allowedthemes`
     Then STDOUT should not contain:
       """
-      'moina-blog' => true
+      'oceanly-green' => true
       """
 
   Scenario: Enabling and disabling a theme without multisite
@@ -426,13 +426,13 @@ Feature: Manage WordPress themes
   @require-wp-5.7
   Scenario: Install and attempt to activate a child theme without its parent
     Given a WP install
-    And I run `wp theme install moina-blog`
-    And I run `rm -rf wp-content/themes/moina`
+    And I run `wp theme install oceanly-green`
+    And I run `rm -rf wp-content/themes/oceanly`
 
-    When I try `wp theme activate moina-blog`
+    When I try `wp theme activate oceanly-green`
     Then STDERR should contain:
       """
-      Error: The parent theme is missing. Please install the "moina" parent theme.
+      Error: The parent theme is missing. Please install the "oceanly" parent theme.
       """
     And STDOUT should be empty
     And the return code should be 1
@@ -440,49 +440,49 @@ Feature: Manage WordPress themes
   @require-wp-5.7
   Scenario: List an active theme with its parent
     Given a WP install
-    And I run `wp theme install moina`
-    And I run `wp theme install --activate moina-blog`
+    And I run `wp theme install oceanly`
+    And I run `wp theme install --activate oceanly-green`
 
     # Hybrid_Registry throws warning for PHP 8+.
     When I try `wp theme list --fields=name,status`
     Then STDOUT should be a table containing rows:
       | name          | status   |
-      | moina-blog    | active   |
-      | moina         | parent   |
+      | oceanly-green | active   |
+      | oceanly       | parent   |
 
   @require-wp-5.7
   Scenario: List broken themes (child theme without parent)
     Given a WP install
-    And I run `wp theme install moina`
-    And I run `wp theme install moina-blog`
+    And I run `wp theme install oceanly`
+    And I run `wp theme install oceanly-green`
     
     When I run `wp theme list --fields=name,status`
     Then STDOUT should be a table containing rows:
       | name          | status   |
-      | moina-blog    | inactive |
-      | moina         | inactive |
+      | oceanly-green | inactive |
+      | oceanly       | inactive |
     
-    When I run `wp theme delete moina`
+    When I run `wp theme delete oceanly`
     Then STDOUT should contain:
       """
-      Deleted 'moina' theme.
+      Deleted 'oceanly' theme.
       """
     
     When I run `wp theme list --fields=name,status`
     Then STDOUT should be a table containing rows:
       | name          | status   |
-      | moina-blog    | inactive |
+      | oceanly-green | inactive |
     
-    When I try `wp theme activate moina-blog`
+    When I try `wp theme activate oceanly-green`
     Then STDERR should contain:
       """
-      Error: The parent theme is missing. Please install the "moina" parent theme.
+      Error: The parent theme is missing. Please install the "oceanly" parent theme.
       """
     
-    When I try `wp theme install moina-blog`
+    When I try `wp theme install oceanly-green`
     Then STDERR should contain:
       """
-      Warning: moina-blog: Theme already installed.
+      Warning: oceanly-green: Theme already installed.
       """
 
   Scenario: When updating a theme --format should be the same when using --dry-run
@@ -555,24 +555,24 @@ Feature: Manage WordPress themes
   Scenario: Automatically install parent theme for a child theme
     Given a WP install
 
-    When I try `wp theme status moina`
+    When I try `wp theme status oceanly`
     Then STDERR should contain:
       """
-      Error: The 'moina' theme could not be found.
+      Error: The 'oceanly' theme could not be found.
       """
     And STDOUT should be empty
     And the return code should be 1
 
-    When I run `wp theme install moina-blog`
+    When I run `wp theme install oceanly-green`
     Then STDOUT should contain:
       """
       This theme requires a parent theme. Checking if it is installed
       """
 
-    When I try `wp theme status moina`
+    When I try `wp theme status oceanly`
     Then STDOUT should contain:
       """
-      Theme moina details:
+      Theme oceanly details:
       """
     And STDERR should contain:
       """
@@ -669,12 +669,12 @@ Feature: Manage WordPress themes
     Given a WP install
     And I run `wp theme delete --all --force`
     And I run `wp theme install twentytwelve`
-    And I run `wp theme install moina-blog --activate`
+    And I run `wp theme install oceanly-green --activate`
 
-    When I run `wp theme is-active moina-blog`
+    When I run `wp theme is-active oceanly-green`
     Then the return code should be 0
 
-    When I run `wp theme is-active moina`
+    When I run `wp theme is-active oceanly`
     Then the return code should be 0
 
     When I try `wp theme is-active twentytwelve`

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -210,7 +210,7 @@ Feature: Manage WordPress themes and plugins
 
     Examples:
       | type   | type_name | item                    | item_title              | version | zip_file                                                               | file_to_check                                                     |
-      | theme  | Theme     | oceanly                 | Oceanly                 | 1.0.0   | https://wordpress.org/themes/download/oceanly.1.0.0.zip                | {CONTENT_DIR}/oceanly/style.css                                   |
+      | theme  | Theme     | storefront              | Storefront              | 1.0.0   | https://wordpress.org/themes/download/storefront.1.0.0.zip             | {CONTENT_DIR}/storefront/style.css                                |
       | plugin | Plugin    | category-checklist-tree | Category Checklist Tree | 1.2     | https://downloads.wordpress.org/plugin/category-checklist-tree.1.2.zip | {CONTENT_DIR}/category-checklist-tree/category-checklist-tree.php |
 
   @require-wp-4.5 @github-api

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -210,7 +210,7 @@ Feature: Manage WordPress themes and plugins
 
     Examples:
       | type   | type_name | item                    | item_title              | version | zip_file                                                               | file_to_check                                                     |
-      | theme  | Theme     | moina                   | Moina                   | 1.1.2   | https://wordpress.org/themes/download/moina.1.1.2.zip                  | {CONTENT_DIR}/moina/style.css                                     |
+      | theme  | Theme     | oceanly                 | Oceanly                 | 1.0.0   | https://wordpress.org/themes/download/oceanly.1.0.0.zip                | {CONTENT_DIR}/oceanly/style.css                                   |
       | plugin | Plugin    | category-checklist-tree | Category Checklist Tree | 1.2     | https://downloads.wordpress.org/plugin/category-checklist-tree.1.2.zip | {CONTENT_DIR}/category-checklist-tree/category-checklist-tree.php |
 
   @require-wp-4.5 @github-api


### PR DESCRIPTION
The `moina` theme requires PHP 7.4+ since yesterday, so some tests using that theme are now failing on PHP 7.2

This PR replaces the theme with `oceanly` and `oceanly-green`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated theme management scenarios to use the Oceanly and Oceanly Green themes.
  * Refreshed installation, update, deletion, activation, multisite, and parent-theme behavior checks.
  * Updated expected theme names, versions, URLs, paths, messages, and command output.
  * Replaced outdated Moina fixtures with Storefront coverage for theme installation, upgrades, and deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->