### PR TITLE
Fix plugin install detection when update info unavailable

### DIFF
--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -165,6 +165,53 @@ Feature: Install WordPress plugins
       """
     And the return code should be 1
 
+  Scenario: Installed plugin is detected even without available update information
+    Given a WP install
+    # `install_plugin_install_status()` falls back to an "install" status if the
+    # WordPress.org API does not offer an update for an outdated plugin.
+    And a wp-content/mu-plugins/no-plugin-updates.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Hide Plugin Updates
+       * Description: Simulates the WordPress.org API not offering any plugin updates
+       * Author: WP-CLI tests
+       */
+      add_filter(
+          'site_transient_update_plugins',
+          function ( $updates ) {
+              if ( is_object( $updates ) ) {
+                  $updates->response = array();
+              }
+              return $updates;
+          },
+          PHP_INT_MAX
+      );
+      """
+    And a wp-content/plugins/debug-bar/debug-bar.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Debug Bar
+       * Version: 0.1
+       */
+      """
+
+    When I try `wp plugin install debug-bar`
+    Then STDOUT should be:
+      """
+      Success: Plugin already installed.
+      """
+    And STDERR should be:
+      """
+      Warning: debug-bar: Plugin already installed.
+      """
+    And STDERR should not contain:
+      """
+      Destination folder already exists
+      """
+    And the return code should be 0
+
   Scenario: Paths aren't backslashed when destination folder already exists
     Given a WP install
 

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -778,9 +778,15 @@ class Plugin_Command extends CommandWithUpgrade {
 
 		$status = install_plugin_install_status( $api );
 
-		if ( ! Utils\get_flag_value( $assoc_args, 'force' ) && 'install' !== $status['status'] ) {
-			// We know this will fail, so avoid a needless download of the package.
-			return new WP_Error( 'already_installed', 'Plugin already installed.' );
+		if ( ! Utils\get_flag_value( $assoc_args, 'force' ) ) {
+			$is_installed = 'install' !== $status['status']
+				|| $this->is_plugin_installed( $slug )
+				|| $this->is_plugin_installed( $api->slug );
+
+			if ( $is_installed ) {
+				// We know this will fail, so avoid a needless download of the package.
+				return new WP_Error( 'already_installed', 'Plugin already installed.' );
+			}
 		}
 
 		WP_CLI::log( sprintf( 'Installing %s (%s)', html_entity_decode( $api->name, ENT_QUOTES ), $api->version ) );
@@ -796,6 +802,30 @@ class Plugin_Command extends CommandWithUpgrade {
 		restore_error_handler();
 
 		return $result;
+	}
+
+	/**
+	 * Checks whether a plugin with the given slug is already installed.
+	 *
+	 * `install_plugin_install_status()` reports an 'install' status for a plugin
+	 * that is already installed when the WordPress.org API does not provide any
+	 * update information for the installed version. This happens for example for
+	 * the Akismet plugin that is bundled with WordPress, whenever the bundled
+	 * version is outdated but no update is being offered for it.
+	 *
+	 * Checking the file system as well makes sure such a plugin is reported as
+	 * being already installed instead of the installation failing with a
+	 * "Destination folder already exists" error.
+	 *
+	 * @param string $slug Plugin slug.
+	 * @return bool Whether the plugin folder holds an installed plugin.
+	 */
+	private function is_plugin_installed( $slug ) {
+		if ( ! is_dir( WP_PLUGIN_DIR . '/' . $slug ) ) {
+			return false;
+		}
+
+		return count( get_plugins( '/' . $slug ) ) > 0;
 	}
 
 	/**


### PR DESCRIPTION
## What

`wp plugin install <slug>` could try to install a plugin that is already installed, failing with `Warning: Destination folder already exists.` instead of reporting `Warning: <slug>: Plugin already installed.`

## Why

`Plugin_Command::install_from_repo()` relied solely on `install_plugin_install_status()`. That function only recognizes an installed plugin when it has update data to compare against:

```php
} else {
	// If the above update check failed, then that probably means that the update checker has out-of-date information, force a refresh.
	if ( ! $loop ) {
		delete_site_transient( 'update_plugins' );
		wp_update_plugins();
		return install_plugin_install_status( $api, true );
	}
}
```

If `plugins_api()` reports a version newer than the installed one and the refreshed `update_plugins` transient still holds no entry for that slug, there is no fallback: the status stays `install` for a plugin that is sitting on disk. WP-CLI then downloads the package and the installation fails on the existing folder.

This broke the `Install dependencies with activation` scenario in the nightly run of 2026-08-18 ([run 32089579364](https://github.com/wp-cli/extension-command/actions/runs/32089579364)) — in every job, WP latest and trunk, PHP 7.4 through nightly:

```
Installing Akismet Anti-spam: Spam Protection (5.7.1)
Downloading installation package from https://downloads.wordpress.org/plugin/akismet.5.7.1.zip...
Unpacking the package...
Installing the plugin...
Plugin installation failed.
[...]
Warning: Destination folder already exists. "{WORKING_DIR}/wp-content/plugins/akismet/"
Error: Only installed 1 of 2 plugins.
```

Nothing changed on our side; the same commit passed the day before. What is certain is that during that run `plugins_api()` offered Akismet 5.7.1 (and `downloads.wordpress.org` served the ZIP), while the `update_plugins` transient held no update entry for the Akismet version bundled with WordPress.

A plausible explanation is the staged distribution of new plugin releases announced in [Protect The Shire](https://wordpress.org/news/2026/06/pts/): Akismet 5.7.1 was released around midnight UTC, and the failing run started at 01:49 UTC. This is not confirmed — the announcement frames the hold in terms of auto-updates, and people have reported seeing such updates offered in wp-admin during the hold — but the timing matches, and re-running the very same workflow later that day passed with no changes.

Either way the fall-through in `install_plugin_install_status()` is real, and it is not Akismet-specific: any plugin installed from WordPress.org can hit it in the window after a release. The same applies outside WP-CLI, where the Add Plugins screen offers "Install Now" for an already installed plugin and fails the same way on click.

## How

Check the file system in addition to the reported status, similar to what `Theme_Command::install_from_repo()` already does via `wp_get_theme( $slug )->exists()`. The new `is_plugin_installed()` helper requires both the directory and a valid plugin file (`get_plugins( '/' . $slug )`), so the existing `Paths aren't backslashed when destination folder already exists` scenario — which deletes `akismet.php` first — keeps working unchanged.

The added scenario reproduces the state deterministically, without depending on WordPress.org timing: an mu-plugin empties `site_transient_update_plugins`, and a stub `debug-bar` 0.1 stands in for the outdated install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeGydmXhxbx34V4UV6M3L6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin installation now recognizes plugins that are already installed, even when update information is unavailable.
  * Added a `--force` option path to allow installation to proceed when needed.

* **Bug Fixes**
  * Prevented unnecessary downloads and destination-folder warnings for already-installed plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->