### PR TITLE
Fix `wp plugin list` fatal on WordPress < 5.3 and quiet the wp-compat false positives

### DIFF
--- a/features/plugin-list-wporg-status.feature
+++ b/features/plugin-list-wporg-status.feature
@@ -110,3 +110,46 @@ Feature: Check the status of plugins on WordPress.org
       | wordpress-importer     | active          | 2025-09-26         |
       | no-longer-in-directory | closed          | 2017-11-13         |
       | never-wporg            |                 |                    |
+
+  @less-than-wp-5.3
+  Scenario: The wp.org last updated date is still rendered on WordPress < 5.3
+    Given a WP install
+    And a wp-content/plugins/wporg-dated/wporg-dated.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Plugin with a WordPress.org release date
+       * Version:     1.0.0
+       */
+      """
+    And that HTTP requests to https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request%5Blocale%5D=en_US&request%5Bslug%5D=wporg-dated will respond with:
+      """
+      HTTP/1.1 200
+      Content-Type: application/json
+
+      {
+        "name": "Plugin with a WordPress.org release date",
+        "slug": "wporg-dated",
+        "last_updated": "2025-09-26 9:07pm GMT"
+      }
+      """
+    And that HTTP requests to https://plugins.trac.wordpress.org/log/wporg-dated/?limit=1&mode=stop_on_copy&format=rss will respond with:
+      """
+      HTTP/1.1 200
+      Content-Type: application/rss+xml;charset=utf-8
+
+      <?xml version="1.0"?>
+        <rss xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+          <channel>
+            <item>
+              <pubDate>Fri, 26 Sep 2025 21:07:26 GMT</pubDate>
+            </item>
+        </channel>
+        </rss>
+      """
+
+    # wp_date() only exists since WordPress 5.3, so this falls back to date_i18n().
+    When I run `wp plugin list --fields=name,wporg_last_updated`
+    Then STDOUT should be a table containing rows:
+      | name        | wporg_last_updated |
+      | wporg-dated | 2025-09-26         |

--- a/features/plugin-list-wporg-status.feature
+++ b/features/plugin-list-wporg-status.feature
@@ -114,6 +114,7 @@ Feature: Check the status of plugins on WordPress.org
   @less-than-wp-5.3
   Scenario: The wp.org last updated date is still rendered on WordPress < 5.3
     Given a WP install
+    And I run `wp option update timezone_string Asia/Tokyo`
     And a wp-content/plugins/wporg-dated/wporg-dated.php file:
       """
       <?php
@@ -148,8 +149,11 @@ Feature: Check the status of plugins on WordPress.org
         </rss>
       """
 
-    # wp_date() only exists since WordPress 5.3, so this falls back to date_i18n().
+    # wp_date() only exists since WordPress 5.3, so this goes through the
+    # get_date_from_gmt() fallback. The pubDate above is 21:07 UTC, which is already
+    # the next day in Asia/Tokyo, so this also pins that the fallback renders in the
+    # site timezone rather than in UTC.
     When I run `wp plugin list --fields=name,wporg_last_updated`
     Then STDOUT should be a table containing rows:
       | name        | wporg_last_updated |
-      | wporg-dated | 2025-09-26         |
+      | wporg-dated | 2025-09-27         |

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,3 +14,22 @@ parameters:
     - identifier: missingType.property
     - identifier: missingType.parameter
     - identifier: missingType.return
+
+    # johnbillion/wp-compat checks every WordPress symbol against the WordPress 4.9
+    # baseline that wp-cli-tests configures. It only recognizes function_exists() and
+    # method_exists() guards, so it cannot see the `wp_version_compare()` checks that
+    # gate the plugin dependency features, and reports those as errors.
+
+    # `wp plugin install --with-dependencies` aborts on WordPress < 6.5 in
+    # `Plugin_Command::install()`, before reaching `get_plugin_dependencies()`, and
+    # `wp plugin install-dependencies` does the same check in the command method itself.
+    -
+      identifier: WPCompat.methodNotAvailable
+      path: src/Plugin_Command.php
+
+    # WordPress 5.3 only formalized the already documented `...$arg` parameter of
+    # `do_action()` by adding it to the function signature. Additional arguments were
+    # collected through `func_get_args()` before that.
+    -
+      identifier: WPCompat.parameterNotAvailable.doaction.arg
+      path: src/Plugin_Command.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,12 +19,17 @@ parameters:
     # baseline that wp-cli-tests configures. It only recognizes function_exists() and
     # method_exists() guards, so it cannot see the `wp_version_compare()` checks that
     # gate the plugin dependency features, and reports those as errors.
+    #
+    # The entries below match on the message as well as the identifier, so that a call to
+    # something introduced later than the version each feature is gated on still gets
+    # reported rather than swallowed by a file-wide ignore.
 
     # `wp plugin install --with-dependencies` aborts on WordPress < 6.5 in
     # `Plugin_Command::install()`, before reaching `get_plugin_dependencies()`, and
     # `wp plugin install-dependencies` does the same check in the command method itself.
     -
       identifier: WPCompat.methodNotAvailable
+      message: '#^WP_Plugin_Dependencies::(get_dependencies|initialize)\(\) is only available since WordPress version 6\.5\.0\.$#'
       path: src/Plugin_Command.php
 
     # WordPress 5.3 only formalized the already documented `...$arg` parameter of

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1124,10 +1124,17 @@ class Plugin_Command extends CommandWithUpgrade {
 				if ( $xml_pub_date ) {
 					$pub_date = strtotime( $xml_pub_date[0] ) ?: null;
 
-					// wp_date() was only introduced in WordPress 5.3.
-					$data['last_updated'] = function_exists( 'wp_date' )
-						? wp_date( 'Y-m-d', $pub_date )
-						: date_i18n( 'Y-m-d', $pub_date ?? false );
+					if ( function_exists( 'wp_date' ) ) {
+						$data['last_updated'] = wp_date( 'Y-m-d', $pub_date );
+					} else {
+						// wp_date() is WordPress 5.3+. get_date_from_gmt() renders in the site
+						// timezone the same way, without date_i18n()'s pre-5.3 contract of
+						// expecting a timestamp that already has the offset added to it.
+						$data['last_updated'] = get_date_from_gmt(
+							gmdate( 'Y-m-d H:i:s', $pub_date ?? time() ),
+							'Y-m-d'
+						);
+					}
 				}
 			}
 		}

--- a/src/Plugin_Command.php
+++ b/src/Plugin_Command.php
@@ -1122,7 +1122,12 @@ class Plugin_Command extends CommandWithUpgrade {
 			if ( false !== $xml ) {
 				$xml_pub_date = $xml->xpath( '//pubDate' );
 				if ( $xml_pub_date ) {
-					$data['last_updated'] = wp_date( 'Y-m-d', strtotime( $xml_pub_date[0] ) ?: null );
+					$pub_date = strtotime( $xml_pub_date[0] ) ?: null;
+
+					// wp_date() was only introduced in WordPress 5.3.
+					$data['last_updated'] = function_exists( 'wp_date' )
+						? wp_date( 'Y-m-d', $pub_date )
+						: date_i18n( 'Y-m-d', $pub_date ?? false );
 				}
 			}
 		}


### PR DESCRIPTION
The `johnbillion/wp-compat` PHPStan extension that now ships with `wp-cli-tests` reported seven errors. It checks every WordPress symbol against the WordPress 4.9 baseline that `wp-cli-tests` configures, and only recognizes `function_exists()` and `method_exists()` guards, so it cannot see `wp_version_compare()` checks.

Six are false positives. One is a real bug.

## The real one

`wp_date()` was introduced in WordPress 5.3, but `Plugin_Command::get_wporg_data()` called it with no guard. That method is reached unconditionally from `get_item_list()`, so **`wp plugin list` fataled on WordPress 4.9 - 5.2** whenever a plugin had a `pubDate` on wordpress.org.

It now falls back to `get_date_from_gmt()`. Erroring out of an entire listing because one field cannot be formatted would be disproportionate, so this degrades rather than fails.

`date_i18n()` was the obvious candidate but is the wrong one, as review on this PR caught. Before WordPress 5.3 it formats with `date( $format, $i )` against PHP's default timezone — which WordPress pins to UTC — and its callers were expected to pass a timestamp that already had the site's GMT offset added. Handing it the true Unix timestamp from `strtotime()` renders the **UTC** date, while `wp_date()` renders the **site-local** one, so the two disagree by a day on non-UTC sites near midnight:

```
unix: 1758920846
UTC   date (date_i18n with a true Unix timestamp): 2025-09-26
Tokyo date (get_date_from_gmt / wp_date):          2025-09-27
```

`get_date_from_gmt()` has been around since WordPress 1.2, handles both `timezone_string` and `gmt_offset`, and is documented to return the date in the site's timezone — so it matches `wp_date()` without inheriting the legacy contract.

## The false positives

| Count | Symbol | Why it is a false positive |
| --- | --- | --- |
| 4 | `WP_Plugin_Dependencies::initialize()` / `::get_dependencies()` (WP 6.5) | Both call paths are gated on `wp_version_compare( '6.5', '<' )` — in `Plugin_Command::install()` for `wp plugin install --with-dependencies`, three frames above the call, and in the command method itself for `wp plugin install-dependencies` |
| 2 | `$arg` parameter of `do_action()` (WP 5.3) | WordPress 5.3 only "formalized the existing and already documented `...$arg` parameter by adding it to the function signature". Additional arguments were collected through `func_get_args()` long before that |

Both are ignored in `phpstan.neon.dist` by error identifier **and** message, naming the symbols and the version they are gated on, so a call to anything newer keeps being reported rather than swallowed by a file-wide ignore.

## Tests

The functional matrix runs WordPress 4.9, where `wp_date()` does not exist. The existing wp.org status scenario is tagged `@require-wp-5.2`, so that path was never exercised on 4.9 and the fatal went unnoticed.

Added a `@less-than-wp-5.3` scenario covering it. It sets the site to `Asia/Tokyo` and keeps the release time at 21:07 UTC, which is already the next day there, so it doubles as the timezone boundary case: it asserts `2025-09-27` and therefore fails if the fallback ever renders in UTC again.

## Verification

Run locally against the same dependency versions CI resolves (`johnbillion/wp-compat` 2.0.0, `php-stubs/wordpress-stubs` v6.9.4, `wp-cli/wp-cli-tests` v5.2.3):

- `composer phpstan` — `[OK] No errors`
- `composer phpcs` — clean
- `php -l` — clean
- `gherkin-lint` 4.2.4 with the org ruleset — clean

Two caveats worth stating plainly. Behat could not be run in my environment (its harness needs a provisioned database), so the new scenario has been linted but never executed. And GitHub Actions was failing to allocate runners across the org while this was written, so CI may need a re-run once that clears.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of WordPress.org plugin release dates on WordPress versions earlier than 5.3.
  * Added compatibility handling so plugin metadata dates are formatted correctly across supported WordPress versions.

* **Tests**
  * Added coverage verifying WordPress.org release dates appear correctly in plugin listings on WordPress 5.2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of WordPress.org plugin release dates on WordPress versions earlier than 5.3.
  * Ensured plugin metadata dates are converted and formatted correctly according to the site’s timezone across supported WordPress versions.

* **Tests**
  * Added coverage verifying release dates appear correctly in plugin listings on WordPress 5.2, including timezone conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->